### PR TITLE
Center the current sample in the zoomed in view

### DIFF
--- a/src/hooks/use-sound-wave-interactions.ts
+++ b/src/hooks/use-sound-wave-interactions.ts
@@ -2,7 +2,8 @@ import { RefObject, useRef } from "react";
 import { ISoundWaveProps } from "../types";
 import { getCurrentSampleX } from "../utils/sound-wave-helpers";
 
-const ZOOM_AREA_INTERACTION_MARGIN = 15;
+// Padding is necessary, as the zoom box might become almost a line for high zoom levels.
+const ZOOM_AREA_INTERACTION_MARGIN = 20; // px
 
 export const useSoundWaveInteractions = (canvasRef: RefObject<HTMLCanvasElement>, props: ISoundWaveProps) => {
   const { width, zoom, onProgressUpdate } = props;

--- a/src/utils/sound-wave-helpers.ts
+++ b/src/utils/sound-wave-helpers.ts
@@ -4,7 +4,8 @@ export const getCurrentAmplitudeY = (props: ISoundWaveProps, index: number) => {
   const { data, volume, height } = props;
   const baseHeight = height * 0.5; // center wave vertically
   const range = height * 0.2; // leave some padding, and space for max volume equal to 2
-  return -data[index] * volume * range + baseHeight;
+  const rawValue = index > 0 && index < data.length ? -data[index] : 0;
+  return rawValue * volume * range + baseHeight;
 };
 
 export const getCurrentSampleIdx = (props: ISoundWaveProps) => {
@@ -15,10 +16,29 @@ export const getCurrentSampleIdx = (props: ISoundWaveProps) => {
   return Math.max(0, Math.floor(data.length * playbackProgress / drawingStep) * drawingStep);
 };
 
+export const getPointsCount =  (props: ISoundWaveProps) => {
+  const { data, zoomedInView } = props;
+  const zoomedInViewPointsCount = getZoomedInViewPointsCount(props);
+  if (zoomedInView) {
+    return zoomedInViewPointsCount;
+  } else {
+    // This math ensures that there's a necessary padding around the sound wave in the zoomed out view.
+    // The padding is based on the zoom level. These calculation could be also written as:
+    // const padding = Math.round(zoomedInViewPointsCount * 0.5);
+    // const pointsCount = data.length + 2 * padding;
+    // Since 2 * padding = zoomedInViewPointsCount, it can be simplified in practice.
+    return data.length + zoomedInViewPointsCount;
+  }
+};
+
+// This makes sense only for zoomed out view. The zoomed in view has the current sample always centered.
 export const getCurrentSampleX = (props: ISoundWaveProps) => {
-  const { width, data, zoomedInView, zoom  } = props;
-  const actualZoom = zoomedInView ? zoom : 1;
-  const segmentWidth = width / data.length * actualZoom;
-  const currentDataPointIdx = getCurrentSampleIdx(props);
-  return currentDataPointIdx * segmentWidth;
+  const { width } = props;
+  const xScale = width / getPointsCount(props);
+  return getCurrentSampleIdx(props) * xScale;
+};
+
+export const getZoomedInViewPointsCount = (props: ISoundWaveProps) => {
+  const { data, zoom } = props;
+  return Math.round(data.length / zoom);
 };


### PR DESCRIPTION
[#179823833]

Now, the current sample is always centered in the top graph. It required adding some padding in both graphs. Demo:
https://soundwaves.concord.org/branch/center-current-sample/index.html

