### PR TITLE
Downsample data before graphing using Audio API

### DIFF
--- a/src/components/sound-wave.tsx
+++ b/src/components/sound-wave.tsx
@@ -1,16 +1,37 @@
-import React, { useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useSoundWaveInteractions } from "../hooks/use-sound-wave-interactions";
 import { useSoundWaveRendering } from "../hooks/use-sound-wave-rendering";
 import { ISoundWaveProps } from "../types";
+import { downsampleAudioBuffer, normalizeData } from "../utils/audio";
 import "./sound-wave.scss";
 
+// Performance - 20k seems to be reasonable limit (tested on desktop Chrome, Safari and iOS Safari)
+const MAX_GRAPH_POINTS = 20000;
+
 export const SoundWave = (props: ISoundWaveProps) => {
-  const { interactive } = props;
+  const { interactive, audioBuffer, zoom, zoomedInView } = props;
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [data, setData] = useState<Float32Array>(new Float32Array(0));
 
-  useSoundWaveRendering(canvasRef, props);
+  useEffect(() => {
+    if (!audioBuffer) {
+      return;
+    }
+    const actualZoom = zoomedInView ? zoom : 1;
+    // Note that maxPointsCount is bigger for zoomed in view, as it displays only fraction of all the points.
+    const maxPointsCount = MAX_GRAPH_POINTS * actualZoom;
+    if (audioBuffer.length > maxPointsCount) {
+      downsampleAudioBuffer(audioBuffer, maxPointsCount).then(result => {
+        setData(normalizeData(result));
+      });
+    } else {
+      // Nothing to do, the original data isn't too large.
+      setData(normalizeData(audioBuffer.getChannelData(0)));
+    }
+  }, [audioBuffer, zoom, zoomedInView]);
 
-  const { handlePointerDown, handlePointerMove } = useSoundWaveInteractions(canvasRef, props);
+  useSoundWaveRendering(canvasRef, data, props);
+  const { handlePointerDown, handlePointerMove } = useSoundWaveInteractions(canvasRef, data, props);
 
   return (
     <div className={`sound-wave ${interactive ? "interactive" : ""}`}>

--- a/src/hooks/use-sound-wave-interactions.ts
+++ b/src/hooks/use-sound-wave-interactions.ts
@@ -1,13 +1,16 @@
 import { RefObject, useRef } from "react";
-import { ISoundWaveProps } from "../types";
+import { ISoundWaveProps, ISoundWavePropsWithData } from "../types";
 import { getCurrentSampleX, getPointsCount, getZoomedInViewPointsCount } from "../utils/sound-wave-helpers";
 
 // Padding is necessary, as the zoom box might become almost a line for high zoom levels.
 const ZOOM_AREA_INTERACTION_MARGIN = 30; // px
 
-export const useSoundWaveInteractions = (canvasRef: RefObject<HTMLCanvasElement>, props: ISoundWaveProps) => {
+export const useSoundWaveInteractions = (canvasRef: RefObject<HTMLCanvasElement>, data: Float32Array, props: ISoundWaveProps) => {
   const { width, zoom, onProgressUpdate } = props;
   const isDraggingActive = useRef(false);
+
+  // Just to keep things simple, provide one props object to all the helpers.
+  const propsWithData: ISoundWavePropsWithData = { ...props, data };
 
   const getRelativeMouseX = (e: { clientX: number }) => {
     return e.clientX - (canvasRef.current?.offsetLeft || 0);
@@ -15,11 +18,11 @@ export const useSoundWaveInteractions = (canvasRef: RefObject<HTMLCanvasElement>
 
   const handlePointerDown = (downEvent: React.PointerEvent) => {
     const startPointerX = getRelativeMouseX(downEvent);
-    const currentPointX = getCurrentSampleX(props);
+    const currentPointX = getCurrentSampleX(propsWithData);
     const zoomAreaX1 = currentPointX - ZOOM_AREA_INTERACTION_MARGIN;
-    const zoomAreaX2 = getCurrentSampleX(props) + width / zoom + ZOOM_AREA_INTERACTION_MARGIN;
-    const zoomedInViewPointsCount = getZoomedInViewPointsCount(props);
-    const pointsCount = getPointsCount(props);
+    const zoomAreaX2 = getCurrentSampleX(propsWithData) + width / zoom + ZOOM_AREA_INTERACTION_MARGIN;
+    const zoomedInViewPointsCount = getZoomedInViewPointsCount(propsWithData);
+    const pointsCount = getPointsCount(propsWithData);
     const zoomedInViewPadding = width * zoomedInViewPointsCount / pointsCount;
 
     if (startPointerX >= zoomAreaX1 && startPointerX <= zoomAreaX2) {
@@ -46,8 +49,8 @@ export const useSoundWaveInteractions = (canvasRef: RefObject<HTMLCanvasElement>
 
   const handlePointerMove = (moveEvent: React.PointerEvent) => {
     const pointerX = getRelativeMouseX(moveEvent);
-    const zoomAreaX1 = getCurrentSampleX(props) - ZOOM_AREA_INTERACTION_MARGIN;
-    const zoomAreaX2 = getCurrentSampleX(props) + width / zoom + ZOOM_AREA_INTERACTION_MARGIN;
+    const zoomAreaX1 = getCurrentSampleX(propsWithData) - ZOOM_AREA_INTERACTION_MARGIN;
+    const zoomAreaX2 = getCurrentSampleX(propsWithData) + width / zoom + ZOOM_AREA_INTERACTION_MARGIN;
 
     if (!isDraggingActive.current && canvasRef.current) {
       if (pointerX >= zoomAreaX1 && pointerX <= zoomAreaX2) {

--- a/src/hooks/use-sound-wave-rendering.ts
+++ b/src/hooks/use-sound-wave-rendering.ts
@@ -4,6 +4,7 @@ import { getCurrentSampleIdx, getCurrentAmplitudeY, getZoomedInViewPointsCount, 
 
 export interface IDrawHelperProps extends ISoundWaveProps {
   ctx: CanvasRenderingContext2D;
+  data: Float32Array;
 }
 
 const drawBackground = (props: IDrawHelperProps) => {
@@ -12,7 +13,7 @@ const drawBackground = (props: IDrawHelperProps) => {
 };
 
 const drawSoundWaveLine = (props: IDrawHelperProps) => {
-  const { ctx, width, drawingStep, zoomedInView } = props;
+  const { ctx, width, zoomedInView } = props;
   const currentDataPointIdx = getCurrentSampleIdx(props);
   const zoomedInViewPointsCount = getZoomedInViewPointsCount(props);
   const pointsCount = getPointsCount(props);
@@ -21,7 +22,7 @@ const drawSoundWaveLine = (props: IDrawHelperProps) => {
   const xScale = width / pointsCount;
   const startIdx = zoomedInView ? currentDataPointIdx - zoomedInViewPadding : -zoomedInViewPadding;
 
-  for (let i = 0; i < pointsCount; i += drawingStep) {
+  for (let i = 0; i < pointsCount; i += 1) {
     ctx.lineTo(i * xScale, getCurrentAmplitudeY(props, i + startIdx));
   }
 
@@ -59,8 +60,8 @@ const drawZoomAreaMarker = (props: IDrawHelperProps) => {
   ctx.fillRect(x * xScale + 0.5 * markerWidth, 0, 1, height); // line
 };
 
-export const useSoundWaveRendering = (canvasRef: RefObject<HTMLCanvasElement>, props: ISoundWaveProps) => {
-  const { width, height, data, volume, playbackProgress, drawingStep, zoom, zoomedInView } = props;
+export const useSoundWaveRendering = (canvasRef: RefObject<HTMLCanvasElement>, data: Float32Array, props: ISoundWaveProps) => {
+  const { width, height, volume, playbackProgress, zoom, zoomedInView } = props;
 
   useEffect(() => {
     if (!canvasRef.current) {
@@ -75,7 +76,7 @@ export const useSoundWaveRendering = (canvasRef: RefObject<HTMLCanvasElement>, p
     }
     // Just to keep things simple, provide one props object to all the helpers.
     const drawHelperProps: IDrawHelperProps = {
-      ctx, width, height, data, volume, playbackProgress, drawingStep, zoom, zoomedInView
+      ctx, width, height, data, volume, playbackProgress, zoom, zoomedInView
     };
 
     drawBackground(drawHelperProps);
@@ -85,5 +86,5 @@ export const useSoundWaveRendering = (canvasRef: RefObject<HTMLCanvasElement>, p
     } else {
       drawZoomAreaMarker(drawHelperProps);
     }
-  }, [canvasRef, width, height, data, volume, playbackProgress, drawingStep, zoom, zoomedInView]);
+  }, [canvasRef, width, height, data, volume, playbackProgress, zoom, zoomedInView]);
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,15 @@
 export interface ISoundWaveProps {
   width: number;
   height: number;
-  data: Float32Array; // normalized, [0, 1]
+  audioBuffer?: AudioBuffer;
   volume: number; // [0, 2], 1 is the default volume
   playbackProgress: number; // normalized, [0, 1]
-  drawingStep: number;
   zoom: number;
   zoomedInView: boolean;
   interactive?: boolean;
   onProgressUpdate?: (newProgress: number) => void;
+}
+
+export interface ISoundWavePropsWithData extends ISoundWaveProps {
+  data: Float32Array;
 }

--- a/src/utils/audio.ts
+++ b/src/utils/audio.ts
@@ -11,3 +11,33 @@ export const normalizeData = (data: Float32Array) => {
   }
   return data;
 };
+
+const MIN_SAMPLE_RATE = 3000; // limit defined by Web Audio API
+export const downsampleAudioBuffer = async (audioBuffer: AudioBuffer, newSamplesCount: number) => {
+  const ratio = newSamplesCount / audioBuffer.length;
+  // audioBuffer.sampleRate
+  const newSampleRate = Math.round(ratio * audioBuffer.sampleRate);
+  const validSampleRate = Math.max(MIN_SAMPLE_RATE, newSampleRate);
+
+  const downsampleContext = new OfflineAudioContext(1, audioBuffer.duration * validSampleRate, validSampleRate);
+  const audioSourceForDownsampling = new AudioBufferSourceNode(downsampleContext, { buffer: audioBuffer });
+  audioSourceForDownsampling.connect(downsampleContext.destination);
+  audioSourceForDownsampling.start(0);
+  const downsampledAudioBuffer = await downsampleContext.startRendering();
+  const data = downsampledAudioBuffer.getChannelData(0);
+
+  if (newSampleRate >= MIN_SAMPLE_RATE) {
+    // Nothing to do, the web browser downsampling is enough as the requested sample rate was > 3000.
+    return data;
+  } else {
+    // Additional downsampling necessary. This is a naive version that takes every Nth sample.
+    // It's not perfect, but most likely it'll never has to be used if the sound files are shorter than 6.6 seconds.
+    // (6.6s * 3000 = 19800 samples and 198000 < 20000 that sound wave graphs uses as a limit of points).
+    const step = Math.ceil(MIN_SAMPLE_RATE / newSampleRate);
+    const finalData = new Float32Array(Math.round(data.length / step));
+    for (let i = 0; i < finalData.length; i += 1) {
+      finalData[i] = data[i * step];
+    }
+    return finalData;
+  }
+};

--- a/src/utils/sound-wave-helpers.ts
+++ b/src/utils/sound-wave-helpers.ts
@@ -1,6 +1,6 @@
-import { ISoundWaveProps } from "../types";
+import { ISoundWavePropsWithData } from "../types";
 
-export const getCurrentAmplitudeY = (props: ISoundWaveProps, index: number) => {
+export const getCurrentAmplitudeY = (props: ISoundWavePropsWithData, index: number) => {
   const { data, volume, height } = props;
   const baseHeight = height * 0.5; // center wave vertically
   const range = height * 0.2; // leave some padding, and space for max volume equal to 2
@@ -8,15 +8,12 @@ export const getCurrentAmplitudeY = (props: ISoundWaveProps, index: number) => {
   return rawValue * volume * range + baseHeight;
 };
 
-export const getCurrentSampleIdx = (props: ISoundWaveProps) => {
-  const { data, drawingStep, playbackProgress } = props;
-  // If drawStep is equal to X, it means that we'll draw only every 10th point.
-  // In this case, it's necessary to divide value by X, use Math.floor, and multiply by X
-  // to ensure that possible index values are only multiplies of X.
-  return Math.max(0, Math.floor(data.length * playbackProgress / drawingStep) * drawingStep);
+export const getCurrentSampleIdx = (props: ISoundWavePropsWithData) => {
+  const { data, playbackProgress } = props;
+  return Math.max(0, Math.floor(data.length * playbackProgress));
 };
 
-export const getPointsCount =  (props: ISoundWaveProps) => {
+export const getPointsCount =  (props: ISoundWavePropsWithData) => {
   const { data, zoomedInView } = props;
   const zoomedInViewPointsCount = getZoomedInViewPointsCount(props);
   if (zoomedInView) {
@@ -32,13 +29,13 @@ export const getPointsCount =  (props: ISoundWaveProps) => {
 };
 
 // This makes sense only for zoomed out view. The zoomed in view has the current sample always centered.
-export const getCurrentSampleX = (props: ISoundWaveProps) => {
+export const getCurrentSampleX = (props: ISoundWavePropsWithData) => {
   const { width } = props;
   const xScale = width / getPointsCount(props);
   return getCurrentSampleIdx(props) * xScale;
 };
 
-export const getZoomedInViewPointsCount = (props: ISoundWaveProps) => {
+export const getZoomedInViewPointsCount = (props: ISoundWavePropsWithData) => {
   const { data, zoom } = props;
   return Math.round(data.length / zoom);
 };


### PR DESCRIPTION
Data is now downsampled using native browser algorithm to avoid issues described here:
https://www.pivotaltracker.com/story/show/179903034

It's implemented in `downsampleAudioBuffer` helper which uses OfflineAudioContext with a smaller sample rate.
I've also changed props of `SoundWave` component - it doesn't accept `data` and `drawingStep` anymore. Instead, I'm passing the whole `AudioBuffer` and this component will reduce the number of points itself, following the defined max points count (currently 20 000, as it seemed fast enough everywhere where I checked).

There's a chance that `downsampleAudioBuffer` will have to use naive downsampling based on the skipping data points, but it shouldn't happen when we use final, shorter audio files.

Also, I might need to replace the current algorithm anyway, as it's browser-specific and it turns out that it doesn't work great on mobile Safari. I'll test it more. 

But I think this PR is worth merging anyway - downsampling is organized better and swapping the downsampling algorithm will be easy now (just update `downsampleAudioBuffer`).