### PR TITLE
180155529 time units on x axis

### DIFF
--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -61,6 +61,7 @@ BODY {
       height: 20px;
       width: 20px;
       margin-top: -7px;
+      border-color: $controls;
       background-color: $controls;
       &:active, &:hover {
         box-shadow: none;
@@ -101,10 +102,8 @@ BODY {
 
     .volume-controls {
       width: 100%;
-      margin-left: 12px;
+      margin-left: 6px;
       display: flex;
-      flex-direction: column;
-      align-items: center;
 
       & > * {
         margin: 0;
@@ -114,28 +113,18 @@ BODY {
         margin-right: 2px;
       }
 
-      .volume-label {
-        margin-bottom: 5px;
-        text-align: center;
-        font-size: 70%;
-        color: $controls;
+      .volume-icon {
+        height: 48px;
+        width: 48px;
       }
 
-      .volume-icons {
-        width: 100%;
-        display: flex;
-        justify-content: space-between;
-
-        DIV {
-          flex: 1 1 auto;
-        }
-        .volume-icon {
-          height: 12px;
-          width: 12px;
-        }
+      .volume-slider-container {
+        width: calc(100% - 50px);
+        margin-top: 16px;
       }
 
       .volume-slider {
+        width: 40%;
         .rc-slider-track {
           background-color: $controls;
           height: 6px;
@@ -148,6 +137,7 @@ BODY {
           height: 20px;
           width: 20px;
           margin-top: -7px;
+          border-color: $controls;
           background-color: $controls;
           &:active, &:hover {
             box-shadow: none;

--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -153,15 +153,21 @@ BODY {
 
   .zoomed-out-graph-container {
     margin: 0;
-    margin-top: -6px;
+    margin-top: -11px;
     display: flex;
     align-items: center;
     height: 60px;
     padding: 3px 5px 0 10px;
-    border: $borderWidth solid $darkBorderColor;
-    border-bottom-left-radius: $borderRadius;
-    border-bottom-right-radius: $borderRadius;
-  }
 
+    &.chosen-sound {
+      border: $borderWidth solid $darkBorderColor;
+      border-bottom-left-radius: $borderRadius;
+      border-bottom-right-radius: $borderRadius;
+    }
+
+    &.chosen-carrier {
+      border-bottom: $borderWidth solid $darkBorderColor;
+    }
+  }
 } // END OF: .app
 

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -254,7 +254,7 @@ export const App = () => {
             zoomedInView={true}
             shouldDrawProgressMarker={true}
           />
-          <div className="zoomed-out-graph-container">
+          <div className="zoomed-out-graph-container chosen-sound">
             <SoundWave
               width={graphWidth - ZOOM_BUTTONS_WIDTH}
               height={ZOOMED_OUT_GRAPH_HEIGHT}

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -249,7 +249,6 @@ export const App = () => {
             playbackProgress={playbackProgress}
             zoom={zoom}
             zoomedInView={true}
-            isCarrierWave={false}
             shouldDrawProgressMarker={true}
           />
           <div className="zoomed-out-graph-container chosen-sound">
@@ -261,7 +260,6 @@ export const App = () => {
               playbackProgress={playbackProgress}
               zoom={zoom}
               zoomedInView={false}
-              isCarrierWave={false}
               shouldDrawProgressMarker={false}
               interactive={!playing}
               onProgressUpdate={handleProgressUpdate}

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -1,7 +1,7 @@
 import React, { ChangeEvent, useCallback, useEffect, useRef, useState } from "react";
 import Slider from "rc-slider";
 
-import { SIDE_MARGIN_PLUS_BORDER, SoundName, SOUND_WAVE_GRAPH_HEIGHT, ZOOMED_OUT_GRAPH_HEIGHT, ZOOM_BUTTONS_WIDTH } from "../types";
+import { SIDE_MARGIN_PLUS_BORDER, SoundName, SOUND_WAVE_GRAPH_HEIGHT, ZOOMED_OUT_GRAPH_HEIGHT, ZOOM_BUTTONS_WIDTH, SOUND_SAMPLE_RATE } from "../types";
 import { SoundWave } from "./sound-wave";
 import { CarrierWave } from "./carrier-wave/carrier-wave";
 import { AppHeader } from "./application-header/application-header";
@@ -63,6 +63,7 @@ export const App = () => {
 
   const setupAudioContextFromRecording = (recordingBuffer: AudioBuffer) => {
     setAudioBuffer(recordingBuffer);
+console.log("setupAudioContextFromRecording", {audioBuffer});
     setPlaybackProgress(0);
   };
 
@@ -78,16 +79,14 @@ export const App = () => {
     // update the playback progress indicator, so that it is clear that there
     // is nothing recorded (yet).
     if (soundName === "record-my-own") {
-      // Arbitrary value--it just needs to be in the legal range, per the API specification
-      const minSupportedSampleRate = 44100;
-
       const emptyBuffer = new AudioBuffer({
         length: 1,
-        sampleRate: minSupportedSampleRate
+        sampleRate: SOUND_SAMPLE_RATE
       });
       audioContext.current = new AudioContext();
       gainNode.current = audioContext.current.createGain();
       setAudioBuffer(emptyBuffer);
+console.log("setupAudioContext", {audioBuffer});
       setPlaybackProgress(0);
       return;
     }
@@ -99,6 +98,7 @@ export const App = () => {
     gainNode.current = audioContext.current.createGain();
 
     setAudioBuffer(await audioContext.current.decodeAudioData(soundArrayBuffer));
+console.log("setupAudioContext() -- after decoding", {audioBuffer});
     setPlaybackProgress(0);
   };
 
@@ -252,7 +252,9 @@ export const App = () => {
             playbackProgress={playbackProgress}
             zoom={zoom}
             zoomedInView={true}
+            isCarrierWave={false}
             shouldDrawProgressMarker={true}
+            // shouldDrawTimeMarker={!playing}
           />
           <div className="zoomed-out-graph-container chosen-sound">
             <SoundWave
@@ -263,9 +265,11 @@ export const App = () => {
               playbackProgress={playbackProgress}
               zoom={zoom}
               zoomedInView={false}
+              isCarrierWave={false}
               shouldDrawProgressMarker={false}
               interactive={!playing}
               onProgressUpdate={handleProgressUpdate}
+              // shouldDrawTimeMarker={false}
             />
             <ZoomButtons handleZoomIn={handleZoomIn} handleZoomOut={handleZoomOut} />
           </div>

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -211,24 +211,16 @@ export const App = () => {
             { playing ? <PauseIcon /> : <PlayIcon /> }
           </div>
           <div className="volume-controls">
-            <div className="volume-label">
-              Volume
+            <div>
+              <VolumeIcon className="volume-icon" />
             </div>
-            <div style={{ width: "100%" }}>
+            <div className="volume-slider-container">
               <Slider
                 className="volume-slider"
                 min={0} max={2} step={0.01}
                 value={volume}
                 onChange={handleVolumeChange}
               />
-            </div>
-            <div className="volume-icons">
-              <div><VolumeIcon className="volume-icon" /></div>
-              <div style={{ textAlign: "right" }}>
-                <VolumeIcon className="volume-icon" />
-                <VolumeIcon className="volume-icon" />
-                <VolumeIcon className="volume-icon" />
-              </div>
             </div>
           </div>
         </div>

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -63,7 +63,6 @@ export const App = () => {
 
   const setupAudioContextFromRecording = (recordingBuffer: AudioBuffer) => {
     setAudioBuffer(recordingBuffer);
-console.log("setupAudioContextFromRecording", {audioBuffer});
     setPlaybackProgress(0);
   };
 
@@ -86,7 +85,6 @@ console.log("setupAudioContextFromRecording", {audioBuffer});
       audioContext.current = new AudioContext();
       gainNode.current = audioContext.current.createGain();
       setAudioBuffer(emptyBuffer);
-console.log("setupAudioContext", {audioBuffer});
       setPlaybackProgress(0);
       return;
     }
@@ -98,7 +96,6 @@ console.log("setupAudioContext", {audioBuffer});
     gainNode.current = audioContext.current.createGain();
 
     setAudioBuffer(await audioContext.current.decodeAudioData(soundArrayBuffer));
-console.log("setupAudioContext() -- after decoding", {audioBuffer});
     setPlaybackProgress(0);
   };
 
@@ -254,7 +251,6 @@ console.log("setupAudioContext() -- after decoding", {audioBuffer});
             zoomedInView={true}
             isCarrierWave={false}
             shouldDrawProgressMarker={true}
-            // shouldDrawTimeMarker={!playing}
           />
           <div className="zoomed-out-graph-container chosen-sound">
             <SoundWave
@@ -269,7 +265,6 @@ console.log("setupAudioContext() -- after decoding", {audioBuffer});
               shouldDrawProgressMarker={false}
               interactive={!playing}
               onProgressUpdate={handleProgressUpdate}
-              // shouldDrawTimeMarker={false}
             />
             <ZoomButtons handleZoomIn={handleZoomIn} handleZoomOut={handleZoomOut} />
           </div>

--- a/src/components/carrier-wave/carrier-wave.tsx
+++ b/src/components/carrier-wave/carrier-wave.tsx
@@ -96,7 +96,7 @@ export const CarrierWave = (props: ICarrierWaveProps) => {
             interactive={false}
           />
         </div>
-        <div className="zoomed-out-graph-container">
+        <div className="zoomed-out-graph-container chosen-carrier">
           <SoundWave
             width={graphWidth - ZOOM_BUTTONS_WIDTH}
             height={ZOOMED_OUT_GRAPH_HEIGHT}

--- a/src/components/carrier-wave/carrier-wave.tsx
+++ b/src/components/carrier-wave/carrier-wave.tsx
@@ -98,9 +98,7 @@ export const CarrierWave = (props: ICarrierWaveProps) => {
             playbackProgress={playbackProgress}
             zoom={carrierZoom}
             zoomedInView={true}
-            isCarrierWave={true}
             shouldDrawProgressMarker={true}
-            // shouldDrawTimeMarker={false}
             interactive={false}
           />
         </div>
@@ -113,9 +111,7 @@ export const CarrierWave = (props: ICarrierWaveProps) => {
             playbackProgress={playbackProgress}
             zoom={carrierZoom}
             zoomedInView={false}
-            isCarrierWave={true}
             shouldDrawProgressMarker={false}
-            // shouldDrawTimeMarker={false}
             interactive={interactive}
             onProgressUpdate={onProgressUpdate}
           />

--- a/src/components/carrier-wave/carrier-wave.tsx
+++ b/src/components/carrier-wave/carrier-wave.tsx
@@ -98,7 +98,9 @@ export const CarrierWave = (props: ICarrierWaveProps) => {
             playbackProgress={playbackProgress}
             zoom={carrierZoom}
             zoomedInView={true}
+            isCarrierWave={true}
             shouldDrawProgressMarker={true}
+            // shouldDrawTimeMarker={false}
             interactive={false}
           />
         </div>
@@ -111,7 +113,9 @@ export const CarrierWave = (props: ICarrierWaveProps) => {
             playbackProgress={playbackProgress}
             zoom={carrierZoom}
             zoomedInView={false}
+            isCarrierWave={true}
             shouldDrawProgressMarker={false}
+            // shouldDrawTimeMarker={false}
             interactive={interactive}
             onProgressUpdate={onProgressUpdate}
           />

--- a/src/components/sound-wave.tsx
+++ b/src/components/sound-wave.tsx
@@ -9,7 +9,7 @@ import "./sound-wave.scss";
 const MAX_GRAPH_POINTS = 20000;
 
 export const SoundWave = (props: ISoundWaveProps) => {
-  const { interactive, audioBuffer, zoom, zoomedInView, isCarrierWave } = props;
+  const { interactive, audioBuffer, zoom, zoomedInView } = props;
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [data, setData] = useState<Float32Array>(new Float32Array(0));
 

--- a/src/components/sound-wave.tsx
+++ b/src/components/sound-wave.tsx
@@ -9,7 +9,10 @@ import "./sound-wave.scss";
 const MAX_GRAPH_POINTS = 20000;
 
 export const SoundWave = (props: ISoundWaveProps) => {
-  const { interactive, audioBuffer, zoom, zoomedInView } = props;
+  const { interactive, audioBuffer, zoom, zoomedInView, isCarrierWave } = props;
+if (zoomedInView && !isCarrierWave) {
+  console.log("SoundWave", {audioBuffer}, audioBuffer?.sampleRate);
+}
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [data, setData] = useState<Float32Array>(new Float32Array(0));
 

--- a/src/components/sound-wave.tsx
+++ b/src/components/sound-wave.tsx
@@ -10,9 +10,6 @@ const MAX_GRAPH_POINTS = 20000;
 
 export const SoundWave = (props: ISoundWaveProps) => {
   const { interactive, audioBuffer, zoom, zoomedInView, isCarrierWave } = props;
-if (zoomedInView && !isCarrierWave) {
-  console.log("SoundWave", {audioBuffer}, audioBuffer?.sampleRate);
-}
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [data, setData] = useState<Float32Array>(new Float32Array(0));
 

--- a/src/hooks/use-sound-wave-rendering.ts
+++ b/src/hooks/use-sound-wave-rendering.ts
@@ -1,4 +1,4 @@
-import { RefObject, useEffect } from "react";
+import { createContext, RefObject, useEffect } from "react";
 import { ISoundWaveProps } from "../types";
 import { getCurrentSampleIdx, getCurrentAmplitudeY, getZoomedInViewPointsCount, getPointsCount } from "../utils/sound-wave-helpers";
 
@@ -10,6 +10,52 @@ export interface IDrawHelperProps extends ISoundWaveProps {
 const drawBackground = (props: IDrawHelperProps) => {
   const { ctx, width, height } = props;
   ctx.clearRect(0, 0, width, height);
+};
+
+const drawTimeCaptions = (props: IDrawHelperProps) => {
+  const { ctx, width, height, zoomedInView, zoom, isCarrierWave, data, audioBuffer } = props;
+
+  // Only render time values for the zoomed in view.
+  if (!zoomedInView) { return; }
+if (isCarrierWave) return;
+// console.log({playbackProgress});
+// console.log({isCarrierWave});
+// console.log({audioBuffer});
+// console.log({data});
+
+  // Need the audioBuffer to calculate
+  if (!audioBuffer) { return; }
+  const timePerSample = 1 / audioBuffer.sampleRate;
+  const currentDataPointIdx = getCurrentSampleIdx(props);
+  const zoomedInViewPointsCount = getZoomedInViewPointsCount(props);
+  const leftRightOffset = (zoomedInViewPointsCount / 2)
+
+
+
+  const timeIndexInSeconds = timePerSample * currentDataPointIdx;
+  const timeIndex = Math.round(timeIndexInSeconds * 1000);
+  const timeIndexLeft = timeIndex - 50;
+  const timeIndexRight = timeIndex + 50;
+
+const pointsCount = getPointsCount(props);
+const xScale = width / getPointsCount(props);
+
+console.log({zoom}, data.length, {currentDataPointIdx});
+console.log({width}, {xScale}, {zoomedInViewPointsCount}, {pointsCount});
+
+  const textPadding = 4;
+  const textLeftLocation = textPadding;
+  const textRightLocation = width - textPadding;
+  const textCenterLocation = width / 2;
+  const textBaselineYlocation = height - (textPadding);
+
+  ctx.font = "'Comfortaa', cursive";
+  ctx.textAlign = "left";
+  ctx.fillText(`${timeIndexLeft} ms`, textLeftLocation, textBaselineYlocation);
+  ctx.textAlign = "center";
+  ctx.fillText(`${timeIndex} ms`, textCenterLocation, textBaselineYlocation);
+  ctx.textAlign = "right";
+  ctx.fillText(`${timeIndexRight} ms`, textRightLocation, textBaselineYlocation);
 };
 
 const drawSoundWaveLine = (props: IDrawHelperProps) => {
@@ -61,7 +107,7 @@ const drawZoomAreaMarker = (props: IDrawHelperProps) => {
 };
 
 export const useSoundWaveRendering = (canvasRef: RefObject<HTMLCanvasElement>, data: Float32Array, props: ISoundWaveProps) => {
-  const { width, height, volume, playbackProgress, zoom, zoomedInView, shouldDrawProgressMarker } = props;
+  const { width, height, audioBuffer, volume, playbackProgress, zoom, zoomedInView, isCarrierWave, shouldDrawProgressMarker } = props;
 
   useEffect(() => {
     if (!canvasRef.current) {
@@ -76,10 +122,11 @@ export const useSoundWaveRendering = (canvasRef: RefObject<HTMLCanvasElement>, d
     }
     // Just to keep things simple, provide one props object to all the helpers.
     const drawHelperProps: IDrawHelperProps = {
-      ctx, width, height, data, volume, playbackProgress, zoom, zoomedInView
+      ctx, width, height, audioBuffer, data, volume, playbackProgress, zoom, zoomedInView, isCarrierWave
     };
 
     drawBackground(drawHelperProps);
+    drawTimeCaptions(drawHelperProps);
     drawSoundWaveLine(drawHelperProps);
     if (zoomedInView && shouldDrawProgressMarker) {
       drawProgressMarker(drawHelperProps);

--- a/src/hooks/use-sound-wave-rendering.ts
+++ b/src/hooks/use-sound-wave-rendering.ts
@@ -25,8 +25,8 @@ const drawTimeCaptions = (props: IDrawHelperProps) => {
   const currentDataPointIdx = getCurrentSampleIdx(props);
   const zoomedInViewPointsCount = getZoomedInViewPointsCount(props);
   const leftRightOffsetInSamples = (zoomedInViewPointsCount / 2);
-  const leftRightOffsetInSeconds = timePerSample * leftRightOffsetInSamples;
-  const leftRightOffsetInMilliseconds = Math.round(leftRightOffsetInSeconds * 1000);
+  const leftRightOffsetInMilliseconds =
+    Math.round((timePerSample * leftRightOffsetInSamples) * 1000);
   const timeIndexInSeconds = timePerSample * currentDataPointIdx;
   const timeIndex = Math.round(timeIndexInSeconds * 1000);
   const timeIndexLeft = timeIndex - leftRightOffsetInMilliseconds;
@@ -96,7 +96,7 @@ const drawZoomAreaMarker = (props: IDrawHelperProps) => {
 };
 
 export const useSoundWaveRendering = (canvasRef: RefObject<HTMLCanvasElement>, data: Float32Array, props: ISoundWaveProps) => {
-  const { width, height, audioBuffer, volume, playbackProgress, zoom, zoomedInView, isCarrierWave, shouldDrawProgressMarker } = props;
+  const { width, height, audioBuffer, volume, playbackProgress, zoom, zoomedInView, shouldDrawProgressMarker } = props;
 
   useEffect(() => {
     if (!canvasRef.current) {
@@ -111,7 +111,7 @@ export const useSoundWaveRendering = (canvasRef: RefObject<HTMLCanvasElement>, d
     }
     // Just to keep things simple, provide one props object to all the helpers.
     const drawHelperProps: IDrawHelperProps = {
-      ctx, width, height, audioBuffer, data, volume, playbackProgress, zoom, zoomedInView, isCarrierWave
+      ctx, width, height, audioBuffer, data, volume, playbackProgress, zoom, zoomedInView
     };
 
     drawBackground(drawHelperProps);

--- a/src/hooks/use-sound-wave-rendering.ts
+++ b/src/hooks/use-sound-wave-rendering.ts
@@ -1,4 +1,4 @@
-import { createContext, RefObject, useEffect } from "react";
+import { RefObject, useEffect } from "react";
 import { ISoundWaveProps } from "../types";
 import { getCurrentSampleIdx, getCurrentAmplitudeY, getZoomedInViewPointsCount, getPointsCount } from "../utils/sound-wave-helpers";
 
@@ -122,5 +122,5 @@ export const useSoundWaveRendering = (canvasRef: RefObject<HTMLCanvasElement>, d
     } else {
       drawZoomAreaMarker(drawHelperProps);
     }
-  }, [canvasRef, width, height, data, volume, playbackProgress, zoom, zoomedInView, shouldDrawProgressMarker]);
+  }, [canvasRef, width, height, audioBuffer, data, volume, playbackProgress, zoom, zoomedInView, shouldDrawProgressMarker]);
 };

--- a/src/hooks/use-sound-wave-rendering.ts
+++ b/src/hooks/use-sound-wave-rendering.ts
@@ -13,35 +13,24 @@ const drawBackground = (props: IDrawHelperProps) => {
 };
 
 const drawTimeCaptions = (props: IDrawHelperProps) => {
-  const { ctx, width, height, zoomedInView, zoom, isCarrierWave, data, audioBuffer } = props;
+  const { ctx, width, height, zoomedInView, audioBuffer } = props;
 
   // Only render time values for the zoomed in view.
   if (!zoomedInView) { return; }
-if (isCarrierWave) return;
-// console.log({playbackProgress});
-// console.log({isCarrierWave});
-// console.log({audioBuffer});
-// console.log({data});
 
   // Need the audioBuffer to calculate
   if (!audioBuffer) { return; }
+
   const timePerSample = 1 / audioBuffer.sampleRate;
   const currentDataPointIdx = getCurrentSampleIdx(props);
   const zoomedInViewPointsCount = getZoomedInViewPointsCount(props);
-  const leftRightOffset = (zoomedInViewPointsCount / 2)
-
-
-
+  const leftRightOffsetInSamples = (zoomedInViewPointsCount / 2);
+  const leftRightOffsetInSeconds = timePerSample * leftRightOffsetInSamples;
+  const leftRightOffsetInMilliseconds = Math.round(leftRightOffsetInSeconds * 1000);
   const timeIndexInSeconds = timePerSample * currentDataPointIdx;
   const timeIndex = Math.round(timeIndexInSeconds * 1000);
-  const timeIndexLeft = timeIndex - 50;
-  const timeIndexRight = timeIndex + 50;
-
-const pointsCount = getPointsCount(props);
-const xScale = width / getPointsCount(props);
-
-console.log({zoom}, data.length, {currentDataPointIdx});
-console.log({width}, {xScale}, {zoomedInViewPointsCount}, {pointsCount});
+  const timeIndexLeft = timeIndex - leftRightOffsetInMilliseconds;
+  const timeIndexRight = timeIndex + leftRightOffsetInMilliseconds;
 
   const textPadding = 4;
   const textLeftLocation = textPadding;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,12 @@ export const SIDE_MARGIN_PLUS_BORDER = SIDE_MARGIN + BORDER_WIDTH; // Units: px;
 export const SOUND_WAVE_GRAPH_HEIGHT = 105;
 export const ZOOMED_OUT_GRAPH_HEIGHT = 45;
 
+// Arbitrary value (in Hz) -- but it needs to be in valid range, per the API specification.
+// The specification requires browsers to support a range of, at least: 8000..96000
+// See: https://developer.mozilla.org/en-US/docs/Web/API/AudioBuffer/AudioBuffer
+      // const minSupportedSampleRate = 44100;
+export const SOUND_SAMPLE_RATE = 44100;
+
 
 export interface ISoundWaveProps {
   width: number;
@@ -16,7 +22,9 @@ export interface ISoundWaveProps {
   zoomedInView: boolean;
   interactive?: boolean;
   onProgressUpdate?: (newProgress: number) => void;
+  isCarrierWave: boolean;
   shouldDrawProgressMarker?: boolean;
+  // shouldDrawTimeMarker?: boolean;
 }
 
 export interface IZoomButtonsProps {

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,9 +22,7 @@ export interface ISoundWaveProps {
   zoomedInView: boolean;
   interactive?: boolean;
   onProgressUpdate?: (newProgress: number) => void;
-  isCarrierWave: boolean;
   shouldDrawProgressMarker?: boolean;
-  // shouldDrawTimeMarker?: boolean;
 }
 
 export interface IZoomButtonsProps {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,12 +5,11 @@ export const SIDE_MARGIN_PLUS_BORDER = SIDE_MARGIN + BORDER_WIDTH; // Units: px;
 export const SOUND_WAVE_GRAPH_HEIGHT = 105;
 export const ZOOMED_OUT_GRAPH_HEIGHT = 45;
 
-// Arbitrary value (in Hz) -- but it needs to be in valid range, per the API specification.
-// The specification requires browsers to support a range of, at least: 8000..96000
-// See: https://developer.mozilla.org/en-US/docs/Web/API/AudioBuffer/AudioBuffer
-      // const minSupportedSampleRate = 44100;
+// Arbitrary value (in Hz) -- but it needs to be in the valid range, per the API specification.
+// Note: the specification requires browsers to support a range of, at least: 8000..96000
+// See (descriptive): https://developer.mozilla.org/en-US/docs/Web/API/AudioBuffer/AudioBuffer
+// See also (formal): https://webaudio.github.io/web-audio-api/#BaseAudioContent-methods
 export const SOUND_SAMPLE_RATE = 44100;
-
 
 export interface ISoundWaveProps {
   width: number;


### PR DESCRIPTION
- Implements feature to see current playback time index, as well as the timeline endpoints, relative to the SoundWave graph.
- Minor, on request (no ticket): changes volume control back to previous appearance.
- Minor (no ticket): fixes layout & border issues with the zoomed-out graphs.

<img width="387" alt="180155529-time-units-on-x-axis" src="https://user-images.githubusercontent.com/91078832/141534445-8556aefc-e06a-4f19-ab71-014dcff8dcf4.png">


