### PR TITLE
179928016 label wave

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -5,7 +5,7 @@ import { SIDE_MARGIN_PLUS_BORDER, SoundName, SOUND_WAVE_GRAPH_HEIGHT, ZOOMED_OUT
 import { SoundWave } from "./sound-wave";
 import { CarrierWave } from "./carrier-wave/carrier-wave";
 import { AppHeader } from "./application-header/application-header";
-import { SoundPicker } from "./sound-picker/sound-picker";
+import { SoundPicker, isPureTone } from "./sound-picker/sound-picker";
 import { useAutoWidth } from "../hooks/use-auto-width";
 import { ZoomButtons } from "./zoom-buttons/zoom-buttons";
 
@@ -250,6 +250,7 @@ export const App = () => {
             zoom={zoom}
             zoomedInView={true}
             shouldDrawProgressMarker={true}
+            shouldDrawAmplitudeWavelengthCaptions={isPureTone(selectedSound)}
           />
           <div className="zoomed-out-graph-container chosen-sound">
             <SoundWave
@@ -260,7 +261,6 @@ export const App = () => {
               playbackProgress={playbackProgress}
               zoom={zoom}
               zoomedInView={false}
-              shouldDrawProgressMarker={false}
               interactive={!playing}
               onProgressUpdate={handleProgressUpdate}
             />

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -39,6 +39,7 @@ const sounds: Record<SoundName, string> = {
 
 export const App = () => {
   const [selectedSound, setSelectedSound] = useState<SoundName>("middle-c");
+  const [drawWaveLabels, setDrawWaveLabels] = useState<boolean>(false);
   const [playing, setPlaying] = useState<boolean>(false);
   const [volume, setVolume] = useState<number>(1);
   const [zoom, setZoom] = useState<number>(16);
@@ -115,6 +116,10 @@ export const App = () => {
   const handleSoundChange = (event: ChangeEvent<HTMLSelectElement>) => {
     const soundName = event.currentTarget.value as SoundName;
     setSelectedSound(soundName);
+  };
+
+  const handleDrawWaveLabelChange = () => {
+    setDrawWaveLabels(!drawWaveLabels);
   };
 
   const handleVolumeChange = (value: number) => {
@@ -198,7 +203,9 @@ export const App = () => {
       <AppHeader />
       <SoundPicker
         selectedSound={selectedSound}
+        drawWaveLabels={drawWaveLabels}
         handleSoundChange={handleSoundChange}
+        handleDrawWaveLabelChange={handleDrawWaveLabelChange}
         onRecordingCompleted={setupAudioContextFromRecording}
       />
       <div className="main-controls-and-waves-container">
@@ -249,7 +256,8 @@ export const App = () => {
             zoom={zoom}
             zoomedInView={true}
             shouldDrawProgressMarker={true}
-            shouldDrawAmplitudeWavelengthCaptions={isPureTone(selectedSound)}
+            shouldDrawWaveCaptions={
+              isPureTone(selectedSound) && drawWaveLabels}
             pureToneFrequency={pureToneFrequencyFromSoundName(selectedSound)}
           />
           <div className="zoomed-out-graph-container chosen-sound">
@@ -275,6 +283,7 @@ export const App = () => {
         volume={volume}
         interactive={!playing}
         onProgressUpdate={handleProgressUpdate}
+        shouldDrawWaveCaptions={isPureTone(selectedSound) && drawWaveLabels}
       />
     </div>
   );

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -5,7 +5,7 @@ import { SIDE_MARGIN_PLUS_BORDER, SoundName, SOUND_WAVE_GRAPH_HEIGHT, ZOOMED_OUT
 import { SoundWave } from "./sound-wave";
 import { CarrierWave } from "./carrier-wave/carrier-wave";
 import { AppHeader } from "./application-header/application-header";
-import { SoundPicker, isPureTone } from "./sound-picker/sound-picker";
+import { SoundPicker, isPureTone, pureToneFrequencyFromSoundName } from "./sound-picker/sound-picker";
 import { useAutoWidth } from "../hooks/use-auto-width";
 import { ZoomButtons } from "./zoom-buttons/zoom-buttons";
 
@@ -36,7 +36,6 @@ const sounds: Record<SoundName, string> = {
   "scratch-sample": ScratchSampleSound,
   "record-my-own": "record-my-own",
 };
-
 
 export const App = () => {
   const [selectedSound, setSelectedSound] = useState<SoundName>("middle-c");
@@ -251,6 +250,7 @@ export const App = () => {
             zoomedInView={true}
             shouldDrawProgressMarker={true}
             shouldDrawAmplitudeWavelengthCaptions={isPureTone(selectedSound)}
+            pureToneFrequency={pureToneFrequencyFromSoundName(selectedSound)}
           />
           <div className="zoomed-out-graph-container chosen-sound">
             <SoundWave

--- a/src/components/carrier-wave/carrier-wave.test.tsx
+++ b/src/components/carrier-wave/carrier-wave.test.tsx
@@ -10,6 +10,7 @@ describe("CarrierWave", () => {
         graphWidth={200}
         volume={1}
         interactive={false}
+        shouldDrawWaveCaptions={false}
       />);
     expect(screen.getByText("Radio Carrier Wave:")).toBeDefined();
   });

--- a/src/components/carrier-wave/carrier-wave.tsx
+++ b/src/components/carrier-wave/carrier-wave.tsx
@@ -25,10 +25,12 @@ export interface ICarrierWaveProps {
   volume: number;
   onProgressUpdate?: (newProgress: number) => void;
   interactive: boolean;
+  shouldDrawWaveCaptions: boolean;
 }
 
 export const CarrierWave = (props: ICarrierWaveProps) => {
-  const { audioBuffer, playbackProgress, graphWidth, volume, onProgressUpdate, interactive } = props;
+  const { audioBuffer, playbackProgress, graphWidth, volume,
+    onProgressUpdate, interactive, shouldDrawWaveCaptions } = props;
 
   const [carrierBuffer, setCarrierBuffer] = useState<AudioBuffer>();
   const [carrierZoom, setCarrierZoom] = useState<number>(16);
@@ -76,6 +78,10 @@ export const CarrierWave = (props: ICarrierWaveProps) => {
     return optionElements;
   };
 
+  const shouldDrawCaptions = (): boolean => {
+    return shouldDrawWaveCaptions && (modulation !== "");
+  };
+
   return (
     <div className="carrier-wave-container">
       <div className="carrier-picker-container">
@@ -99,7 +105,7 @@ export const CarrierWave = (props: ICarrierWaveProps) => {
             zoom={carrierZoom}
             zoomedInView={true}
             shouldDrawProgressMarker={(modulation !== "")}
-            shouldDrawAmplitudeWavelengthCaptions={(modulation !== "")}
+            shouldDrawWaveCaptions={shouldDrawCaptions()}
             pureToneFrequency={carrierFrequency}
             interactive={false}
           />

--- a/src/components/carrier-wave/carrier-wave.tsx
+++ b/src/components/carrier-wave/carrier-wave.tsx
@@ -98,7 +98,8 @@ export const CarrierWave = (props: ICarrierWaveProps) => {
             playbackProgress={playbackProgress}
             zoom={carrierZoom}
             zoomedInView={true}
-            shouldDrawProgressMarker={true}
+            shouldDrawProgressMarker={(modulation !== "")}
+            shouldDrawAmplitudeWavelengthCaptions={(modulation !== "")}
             interactive={false}
           />
         </div>
@@ -111,7 +112,6 @@ export const CarrierWave = (props: ICarrierWaveProps) => {
             playbackProgress={playbackProgress}
             zoom={carrierZoom}
             zoomedInView={false}
-            shouldDrawProgressMarker={false}
             interactive={interactive}
             onProgressUpdate={onProgressUpdate}
           />

--- a/src/components/carrier-wave/carrier-wave.tsx
+++ b/src/components/carrier-wave/carrier-wave.tsx
@@ -100,6 +100,7 @@ export const CarrierWave = (props: ICarrierWaveProps) => {
             zoomedInView={true}
             shouldDrawProgressMarker={(modulation !== "")}
             shouldDrawAmplitudeWavelengthCaptions={(modulation !== "")}
+            pureToneFrequency={carrierFrequency}
             interactive={false}
           />
         </div>

--- a/src/components/sound-picker/sound-picker.scss
+++ b/src/components/sound-picker/sound-picker.scss
@@ -20,24 +20,28 @@
       }
   }
 
-  .sound-picker-icons-container {
+  .icons-container {
     width: 74px;
     height: 32px;
     text-align: right;
 
-    .sound-picker-icon {
+    .icon {
       height: 24px;
       width: 24px;
       margin-left: 5px;
       cursor: pointer;
 
+      &.recording {
+        fill: red;
+      }
+
+      &.labelling {
+        fill: blueviolet;
+      }
+
       &.disabled {
         fill: $disabledButton;
         cursor: default;
-      }
-
-      &.recording {
-        fill: red;
       }
     }
   }

--- a/src/components/sound-picker/sound-picker.tsx
+++ b/src/components/sound-picker/sound-picker.tsx
@@ -14,12 +14,17 @@ export interface ISoundPickerProps {
 
 export const isPureTone = (soundName: string) => {
   switch (soundName) {
-    case "middle-c": return true;
-      break;
-    case "c2": return true;
-      break;
-    default:
-      return false;
+    case "middle-c": return true; break;
+    case "c2": return true; break;
+    default: return false;
+  }
+};
+
+export const pureToneFrequencyFromSoundName = (soundName: string) => {
+  switch (soundName) {
+    case "middle-c": return 261.65; break;
+    case "c2": return 65.41; break;
+    default: return 0;
   }
 };
 

--- a/src/components/sound-picker/sound-picker.tsx
+++ b/src/components/sound-picker/sound-picker.tsx
@@ -7,9 +7,11 @@ import LabelsIcon from "../../assets/icons/sell_black_48dp.svg";
 import "./sound-picker.scss";
 
 export interface ISoundPickerProps {
-  selectedSound: SoundName
+  selectedSound: SoundName;
+  drawWaveLabels: boolean;
   handleSoundChange?: (event: ChangeEvent<HTMLSelectElement>) => void;
   onRecordingCompleted?: (audioBuffer: AudioBuffer) => void;
+  handleDrawWaveLabelChange?: () => void;
 }
 
 export const isPureTone = (soundName: string) => {
@@ -29,11 +31,12 @@ export const pureToneFrequencyFromSoundName = (soundName: string) => {
 };
 
 export const SoundPicker = (props: ISoundPickerProps) => {
-  const { selectedSound, handleSoundChange, onRecordingCompleted } = props;
+  const { selectedSound, handleSoundChange, onRecordingCompleted, drawWaveLabels, handleDrawWaveLabelChange } = props;
 
-  // defaults to match default of Middle C selection
+  // Set: isPureToneSelected, isReadyToRecord defaults, based on "middle-c" default selection
   const [isPureToneSelected, setIsPureToneSelected] = useState<boolean>(true);
   const [isReadyToRecord, setIsReadyToRecord] = useState<boolean>(false);
+
   const [isRecording, setIsRecording] = useState<boolean>(false);
 
   const recordingTimerRef = useRef<number>();
@@ -139,6 +142,12 @@ export const SoundPicker = (props: ISoundPickerProps) => {
     }
   };
 
+  const onLabelIconClicked = () => {
+    // Don't allow state change when non-pure tone sound selected
+    if (!isPureToneSelected) { return; }
+    handleDrawWaveLabelChange?.();
+  };
+
   const onSoundPickerChange = (event: ChangeEvent<HTMLSelectElement>) => {
     const soundName = event.currentTarget.value as SoundName;
     setIsPureToneSelected(isPureTone(soundName));
@@ -171,10 +180,14 @@ export const SoundPicker = (props: ISoundPickerProps) => {
           <option value="record-my-own">(record my own . . .)</option>
         </select>
       </div>
-      <div className="sound-picker-icons-container">
-        <MicIcon className={`sound-picker-icon button ${isReadyToRecord ? "" : "disabled"} ${isRecording ? "recording" : ""}`}
+      <div className="icons-container">
+        <MicIcon className={
+          `icon button ${isReadyToRecord ? "" : "disabled"} ${isRecording ? "recording" : ""}`}
           onClick={onMicIconClicked} />
-        <LabelsIcon className={`sound-picker-icon button ${isPureToneSelected ? "" : "disabled"}`} />
+        <LabelsIcon className={
+            `icon button ${isPureToneSelected ? "" : "disabled"} ${drawWaveLabels ? "labelling" : ""}`
+          }
+          onClick={onLabelIconClicked} />
       </div>
     </div>
   );

--- a/src/components/sound-picker/sound-picker.tsx
+++ b/src/components/sound-picker/sound-picker.tsx
@@ -12,6 +12,17 @@ export interface ISoundPickerProps {
   onRecordingCompleted?: (audioBuffer: AudioBuffer) => void;
 }
 
+export const isPureTone = (soundName: string) => {
+  switch (soundName) {
+    case "middle-c": return true;
+      break;
+    case "c2": return true;
+      break;
+    default:
+      return false;
+  }
+};
+
 export const SoundPicker = (props: ISoundPickerProps) => {
   const { selectedSound, handleSoundChange, onRecordingCompleted } = props;
 
@@ -125,17 +136,7 @@ export const SoundPicker = (props: ISoundPickerProps) => {
 
   const onSoundPickerChange = (event: ChangeEvent<HTMLSelectElement>) => {
     const soundName = event.currentTarget.value as SoundName;
-    switch (soundName) {
-      case "middle-c":
-        setIsPureToneSelected(true);
-        break;
-      case "c2":
-        setIsPureToneSelected(true);
-        break;
-      default:
-        setIsPureToneSelected(false);
-    }
-
+    setIsPureToneSelected(isPureTone(soundName));
     const isUserRecordingSelected = soundName === "record-my-own";
     const hasMediaRecorder = !!(mediaRecorderRef.current);
     setIsReadyToRecord(hasMediaRecorder && isUserRecordingSelected);
@@ -145,7 +146,6 @@ export const SoundPicker = (props: ISoundPickerProps) => {
 
     handleSoundChange?.(event);
   };
-
 
   return (
     <div className="sound-picker-container">

--- a/src/components/sound-picker/sound-picker.tsx
+++ b/src/components/sound-picker/sound-picker.tsx
@@ -16,16 +16,16 @@ export interface ISoundPickerProps {
 
 export const isPureTone = (soundName: string) => {
   switch (soundName) {
-    case "middle-c": return true; break;
-    case "c2": return true; break;
+    case "middle-c": return true;
+    case "c2": return true;
     default: return false;
   }
 };
 
 export const pureToneFrequencyFromSoundName = (soundName: string) => {
   switch (soundName) {
-    case "middle-c": return 261.65; break;
-    case "c2": return 65.41; break;
+    case "middle-c": return 261.65;
+    case "c2": return 65.41;
     default: return 0;
   }
 };

--- a/src/hooks/use-sound-wave-rendering.ts
+++ b/src/hooks/use-sound-wave-rendering.ts
@@ -160,52 +160,52 @@ const drawSoundMarkers = (props: IDrawHelperProps) => {
     wavelengthCaptionY + (textBoxHeight / 2) + (textPadding / 2));
 
   // Draw wavelength arrow
-  // const timePerSampleinMs = 1000 / audioBuffer.sampleRate;
-  // const samplesForOneWavelength = wavelengthInMs / timePerSampleinMs;
+  const timePerSampleinMs = 1000 / audioBuffer.sampleRate;
+  const samplesForOneWavelength = wavelengthInMs / timePerSampleinMs;
 
   // console.log({pureToneFrequency},{wavelengthInMs});
   // console.log({audioBuffer},{timePerSample: timePerSampleinMs},{samplesForOneWavelength})
 
-  // // const currentDataPointIdx = getCurrentSampleIdx(props);
+  // const currentDataPointIdx = getCurrentSampleIdx(props);
   // const zoomedInViewPointsCount = getZoomedInViewPointsCount(props);
-  // // const leftRightOffsetInSamples = (zoomedInViewPointsCount / 2);
-  // // const leftRightOffsetInMilliseconds =
-  // //   Math.round((timePerSample * leftRightOffsetInSamples) * 1000);
-  // // const samplesInView = zoomedInViewPointsCount;
+  // const leftRightOffsetInSamples = (zoomedInViewPointsCount / 2);
+  // const leftRightOffsetInMilliseconds =
+  //   Math.round((timePerSample * leftRightOffsetInSamples) * 1000);
+  // const samplesInView = zoomedInViewPointsCount;
   // const millisecondsInView =
   //   Math.round((timePerSampleinMs * zoomedInViewSamplesCount) * 1000);
 
   // const numberOfWavelengthsInView = millisecondsInView / wavelengthInMs;
   // const pointsPerMillisecond = zoomedInViewSamplesCount / millisecondsInView;
-  // // const pxPerWavelength = width / numberOfWavelengthsInView;
-  // const pxPerWavelength = (samplesForOneWavelength * zoom) / 200;
+  // const pxPerWavelength = width / numberOfWavelengthsInView;
+  const pxPerWavelength = (samplesForOneWavelength * zoom);
 
   // console.log({width},{pxPerWavelength})
   // console.log({wavelengthInMs},{millisecondsInView});
   // console.log({zoom},{numberOfWavelengthsInView});
   // console.log({zoomedInViewPointsCount},{pointsPerMillisecond});
 
-  // const arrowWidth = pxPerWavelength; // 35;
-  // const arrowHeadWidth = 8;
-  // const arrowHeadHeight = 3;
-  // ctx.strokeStyle = "black";
-  // ctx.fillRect(width / 2, (height / 2) - 1, arrowWidth, 2);
-  // ctx.beginPath();
-  // ctx.moveTo(width / 2, height / 2);
-  // ctx.lineTo((width / 2) + arrowHeadWidth, (height / 2) + arrowHeadHeight);
-  // ctx.stroke();
-  // ctx.beginPath();
-  // ctx.moveTo(width / 2, height / 2);
-  // ctx.lineTo((width / 2) + arrowHeadWidth, (height / 2) - arrowHeadHeight);
-  // ctx.stroke();
-  // ctx.beginPath();
-  // ctx.moveTo((width / 2) + arrowWidth, height / 2);
-  // ctx.lineTo((width / 2) + arrowWidth - arrowHeadWidth, (height / 2) + arrowHeadHeight);
-  // ctx.stroke();
-  // ctx.beginPath();
-  // ctx.moveTo((width / 2) + arrowWidth, height / 2);
-  // ctx.lineTo((width / 2) + arrowWidth - arrowHeadWidth, (height / 2) - arrowHeadHeight);
-  // ctx.stroke();
+  const arrowWidth = pxPerWavelength;
+  const arrowHeadWidth = 8;
+  const arrowHeadHeight = 3;
+  ctx.strokeStyle = "black";
+  ctx.fillRect(width / 2, (height / 2) - 1, arrowWidth, 2);
+  ctx.beginPath();
+  ctx.moveTo(width / 2, height / 2);
+  ctx.lineTo((width / 2) + arrowHeadWidth, (height / 2) + arrowHeadHeight);
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.moveTo(width / 2, height / 2);
+  ctx.lineTo((width / 2) + arrowHeadWidth, (height / 2) - arrowHeadHeight);
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.moveTo((width / 2) + arrowWidth, height / 2);
+  ctx.lineTo((width / 2) + arrowWidth - arrowHeadWidth, (height / 2) + arrowHeadHeight);
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.moveTo((width / 2) + arrowWidth, height / 2);
+  ctx.lineTo((width / 2) + arrowWidth - arrowHeadWidth, (height / 2) - arrowHeadHeight);
+  ctx.stroke();
 };
 
 export const useSoundWaveRendering = (canvasRef: RefObject<HTMLCanvasElement>, data: Float32Array, props: ISoundWaveProps) => {

--- a/src/hooks/use-sound-wave-rendering.ts
+++ b/src/hooks/use-sound-wave-rendering.ts
@@ -209,7 +209,7 @@ const drawSoundMarkers = (props: IDrawHelperProps) => {
 };
 
 export const useSoundWaveRendering = (canvasRef: RefObject<HTMLCanvasElement>, data: Float32Array, props: ISoundWaveProps) => {
-  const { width, height, audioBuffer, volume, playbackProgress, zoom, zoomedInView, shouldDrawProgressMarker, shouldDrawAmplitudeWavelengthCaptions, pureToneFrequency } = props;
+  const { width, height, audioBuffer, volume, playbackProgress, zoom, zoomedInView, shouldDrawProgressMarker, shouldDrawWaveCaptions: shouldDrawAmplitudeWavelengthCaptions, pureToneFrequency } = props;
 
   useEffect(() => {
     if (!canvasRef.current) {

--- a/src/hooks/use-sound-wave-rendering.ts
+++ b/src/hooks/use-sound-wave-rendering.ts
@@ -94,15 +94,19 @@ const drawZoomAreaMarker = (props: IDrawHelperProps) => {
 
 // Used only in the zoomed in view.
 const drawSoundMarkers = (props: IDrawHelperProps) => {
-  const { ctx, width, height, volume, zoomedInView, pureToneFrequency } = props;
+  const { ctx, width, height, audioBuffer, zoomedInView, zoom, pureToneFrequency } = props;
+
+  // Need the audioBuffer to calculate
+  if (!audioBuffer) { return; }
 
   // Draw AMPLITUDE marker & label...
 
   const pointsCount = getPointsCount(props);
   const currentDataPointIdx = getCurrentSampleIdx(props);
-  const zoomedInViewPointsCount = getZoomedInViewPointsCount(props);
-  const zoomedInViewPadding = Math.round(zoomedInViewPointsCount * 0.5);
-  const startIdx = zoomedInView ? currentDataPointIdx - zoomedInViewPadding : -zoomedInViewPadding;
+  const zoomedInViewSamplesCount = getZoomedInViewPointsCount(props);
+  const zoomedInViewPadding = Math.round(zoomedInViewSamplesCount * 0.5);
+  const startIdx =
+    zoomedInView ? currentDataPointIdx - zoomedInViewPadding : -zoomedInViewPadding;
 
   let minAmplitude = height;
   for (let i = 0; i < pointsCount; i++) {
@@ -116,15 +120,6 @@ const drawSoundMarkers = (props: IDrawHelperProps) => {
   const amplitudeCaptionX = (width / 2);
   // Ensure the Y coordinate is not negative, so that caption is visible
   const amplitudeCaptionY = Math.max(minAmplitude - (textBoxHeight), 0);
-
-// console.log({captionY: amplitudeCaptionY},{volume},{height},{maxAmplitude: minAmplitude});
-
-  // Draw the text background's border
-  // const borderWidth = 1;
-  // ctx.strokeStyle = "fuchsia"; // "#d0d0d080"; // "#ffffff";
-  // ctx.lineWidth = borderWidth;
-  // ctx.strokeRect(amplitudeCaptionX + borderWidth, amplitudeCaptionY + (textBoxHeight / 2),
-  //   textBoxWidth, textBoxHeight);
 
   // Draw (semi-opaque) background for the text
   ctx.fillStyle = "#ffffffb0";
@@ -143,10 +138,11 @@ const drawSoundMarkers = (props: IDrawHelperProps) => {
   ctx.fillStyle = "#303030";
   ctx.fillText(`Amplitude`, textLeftLocation, textBaselineYlocation);
 
-  if (!pureToneFrequency) { return; }
-  const wavelengthInMs = ((1 / pureToneFrequency) * 1000).toPrecision(3);
-
   // Draw the WAVELENGTH marker and label...
+
+  if (!pureToneFrequency) { return; }
+
+  const wavelengthInMs = ((1 / pureToneFrequency) * 1000);
   const wavelengthMargin = 0;
   const wavelengthTextBoxWidth = 120;
   const wavelengthCaptionX = (width / 2) + wavelengthMargin;
@@ -154,43 +150,62 @@ const drawSoundMarkers = (props: IDrawHelperProps) => {
 
   // Draw (semi-opaque) background for the text
   ctx.fillStyle = "#ffffffb0"; //"#f0f00080";
-  ctx.fillRect(wavelengthCaptionX, wavelengthCaptionY,
-  wavelengthTextBoxWidth, textBoxHeight);
+  ctx.fillRect(wavelengthCaptionX, wavelengthCaptionY, wavelengthTextBoxWidth, textBoxHeight);
 
   // Draw label text
   ctx.fillStyle = "#303030";
   ctx.textAlign = "center";
-  ctx.fillText(`wavelength: ${wavelengthInMs}ms`,
+  ctx.fillText(`wavelength: ${wavelengthInMs.toPrecision(3)}ms`,
     wavelengthCaptionX + (wavelengthTextBoxWidth / 2) + (textPadding / 2),
     wavelengthCaptionY + (textBoxHeight / 2) + (textPadding / 2));
 
   // Draw wavelength arrow
-console.log({wavelengthInMs},{zoomedInViewPointsCount})
-  const arrowWidth = 35;
-  const arrowHeadWidth = 8;
-  const arrowHeadHeight = 3;
-  ctx.strokeStyle = "black";
-  ctx.fillRect(width / 2, (height / 2) - 1, arrowWidth, 2);
+  // const timePerSampleinMs = 1000 / audioBuffer.sampleRate;
+  // const samplesForOneWavelength = wavelengthInMs / timePerSampleinMs;
 
-  ctx.beginPath();
-  ctx.moveTo(width / 2, height / 2);
-  ctx.lineTo((width / 2) + arrowHeadWidth, (height / 2) + arrowHeadHeight);
-  ctx.stroke();
+  // console.log({pureToneFrequency},{wavelengthInMs});
+  // console.log({audioBuffer},{timePerSample: timePerSampleinMs},{samplesForOneWavelength})
 
-  ctx.beginPath();
-  ctx.moveTo(width / 2, height / 2);
-  ctx.lineTo((width / 2) + arrowHeadWidth, (height / 2) - arrowHeadHeight);
-  ctx.stroke();
+  // // const currentDataPointIdx = getCurrentSampleIdx(props);
+  // const zoomedInViewPointsCount = getZoomedInViewPointsCount(props);
+  // // const leftRightOffsetInSamples = (zoomedInViewPointsCount / 2);
+  // // const leftRightOffsetInMilliseconds =
+  // //   Math.round((timePerSample * leftRightOffsetInSamples) * 1000);
+  // // const samplesInView = zoomedInViewPointsCount;
+  // const millisecondsInView =
+  //   Math.round((timePerSampleinMs * zoomedInViewSamplesCount) * 1000);
 
-  ctx.beginPath();
-  ctx.moveTo((width / 2) + arrowWidth, height / 2);
-  ctx.lineTo((width / 2) + arrowWidth - arrowHeadWidth, (height / 2) + arrowHeadHeight);
-  ctx.stroke();
+  // const numberOfWavelengthsInView = millisecondsInView / wavelengthInMs;
+  // const pointsPerMillisecond = zoomedInViewSamplesCount / millisecondsInView;
+  // // const pxPerWavelength = width / numberOfWavelengthsInView;
+  // const pxPerWavelength = (samplesForOneWavelength * zoom) / 200;
 
-  ctx.beginPath();
-  ctx.moveTo((width / 2) + arrowWidth, height / 2);
-  ctx.lineTo((width / 2) + arrowWidth - arrowHeadWidth, (height / 2) - arrowHeadHeight);
-  ctx.stroke();
+  // console.log({width},{pxPerWavelength})
+  // console.log({wavelengthInMs},{millisecondsInView});
+  // console.log({zoom},{numberOfWavelengthsInView});
+  // console.log({zoomedInViewPointsCount},{pointsPerMillisecond});
+
+  // const arrowWidth = pxPerWavelength; // 35;
+  // const arrowHeadWidth = 8;
+  // const arrowHeadHeight = 3;
+  // ctx.strokeStyle = "black";
+  // ctx.fillRect(width / 2, (height / 2) - 1, arrowWidth, 2);
+  // ctx.beginPath();
+  // ctx.moveTo(width / 2, height / 2);
+  // ctx.lineTo((width / 2) + arrowHeadWidth, (height / 2) + arrowHeadHeight);
+  // ctx.stroke();
+  // ctx.beginPath();
+  // ctx.moveTo(width / 2, height / 2);
+  // ctx.lineTo((width / 2) + arrowHeadWidth, (height / 2) - arrowHeadHeight);
+  // ctx.stroke();
+  // ctx.beginPath();
+  // ctx.moveTo((width / 2) + arrowWidth, height / 2);
+  // ctx.lineTo((width / 2) + arrowWidth - arrowHeadWidth, (height / 2) + arrowHeadHeight);
+  // ctx.stroke();
+  // ctx.beginPath();
+  // ctx.moveTo((width / 2) + arrowWidth, height / 2);
+  // ctx.lineTo((width / 2) + arrowWidth - arrowHeadWidth, (height / 2) - arrowHeadHeight);
+  // ctx.stroke();
 };
 
 export const useSoundWaveRendering = (canvasRef: RefObject<HTMLCanvasElement>, data: Float32Array, props: ISoundWaveProps) => {
@@ -225,5 +240,5 @@ export const useSoundWaveRendering = (canvasRef: RefObject<HTMLCanvasElement>, d
     } else {
       drawZoomAreaMarker(drawHelperProps);
     }
-  }, [canvasRef, width, height, audioBuffer, data, volume, playbackProgress, zoom, zoomedInView, shouldDrawProgressMarker]);
+  }, [canvasRef, width, height, audioBuffer, data, volume, playbackProgress, zoom, zoomedInView, pureToneFrequency, shouldDrawAmplitudeWavelengthCaptions, shouldDrawProgressMarker]);
 };

--- a/src/hooks/use-sound-wave-rendering.ts
+++ b/src/hooks/use-sound-wave-rendering.ts
@@ -95,8 +95,73 @@ const drawZoomAreaMarker = (props: IDrawHelperProps) => {
   ctx.fillRect(x * xScale + 0.5 * markerWidth, 0, 1, height); // line
 };
 
+// Used only in the zoomed in view.
+// const drawAmplitudeMarker = (props: IDrawHelperProps) => {
+//   const { ctx, width, height } = props;
+
+//   const captionX = (width / 2);
+//   const captionY = (height / 2) - 20; // TODO: set based on max waveform ehight; scaled by volume
+//   const textBoxHeight = 14;
+//   const textBoxWidth = 54;
+//   const textPadding = 4;
+
+//   const borderWidth = 2;
+//   ctx.strokeStyle = "#d0d0d080";// "fuchsia"; // "#ffffff";
+//   ctx.lineWidth = borderWidth;
+//   ctx.strokeRect(captionX + borderWidth, captionY + borderWidth,
+//     textBoxWidth, textBoxHeight);
+
+//   ctx.fillStyle = "#ffffffc0";
+//   ctx.fillRect(captionX + borderWidth + 1, captionY + borderWidth,
+//     textBoxWidth-2, textBoxHeight);
+
+//   const textLeftLocation = captionX + textPadding + 2;
+//   const textBaselineYlocation = captionY + textBoxHeight - (textPadding / 2);
+//   ctx.font = "'Comfortaa', cursive";
+//   ctx.textAlign = "left";
+//   ctx.fillStyle = "#303030";
+//   ctx.fillText(`Amplitude`, textLeftLocation, textBaselineYlocation);
+// };
+
+// Used only in the zoomed in view.
+const drawSoundMarkers = (props: IDrawHelperProps) => {
+  const { ctx, width, height } = props;
+
+  // Draw AMPLITUDE marker
+  const captionX = (width / 2);
+  const captionY = (height / 2) - 20; // TODO: set based on max waveform ehight; scaled by volume
+  const textBoxHeight = 14;
+  const textBoxWidth = 54;
+  const textPadding = 4;
+
+  const borderWidth = 2;
+  ctx.strokeStyle = "#d0d0d080";// "fuchsia"; // "#ffffff";
+  ctx.lineWidth = borderWidth;
+  ctx.strokeRect(captionX + borderWidth, captionY + borderWidth,
+    textBoxWidth, textBoxHeight);
+
+  ctx.fillStyle = "#ffffffc0";
+  ctx.fillRect(captionX + borderWidth + 1, captionY + borderWidth,
+    textBoxWidth-2, textBoxHeight);
+
+  const textLeftLocation = captionX + textPadding + 2;
+  const textBaselineYlocation = captionY + textBoxHeight - (textPadding / 2);
+  ctx.font = "'Comfortaa', cursive";
+  ctx.textAlign = "left";
+  ctx.fillStyle = "#303030";
+  ctx.fillText(`Amplitude`, textLeftLocation, textBaselineYlocation);
+
+// TODO: draw wavelength marker
+
+  // const { ctx, width, height } = props;
+  // ctx.font = "'Comfortaa', cursive";
+  // ctx.textAlign = "left";
+  // // ctx.fillText(`${timeIndexLeft} ms`, textLeftLocation, textBaselineYlocation);
+
+};
+
 export const useSoundWaveRendering = (canvasRef: RefObject<HTMLCanvasElement>, data: Float32Array, props: ISoundWaveProps) => {
-  const { width, height, audioBuffer, volume, playbackProgress, zoom, zoomedInView, shouldDrawProgressMarker } = props;
+  const { width, height, audioBuffer, volume, playbackProgress, zoom, zoomedInView, shouldDrawProgressMarker, shouldDrawAmplitudeWavelengthCaptions } = props;
 
   useEffect(() => {
     if (!canvasRef.current) {
@@ -117,8 +182,14 @@ export const useSoundWaveRendering = (canvasRef: RefObject<HTMLCanvasElement>, d
     drawBackground(drawHelperProps);
     drawTimeCaptions(drawHelperProps);
     drawSoundWaveLine(drawHelperProps);
-    if (zoomedInView && shouldDrawProgressMarker) {
-      drawProgressMarker(drawHelperProps);
+    if (zoomedInView) {
+      if (shouldDrawProgressMarker) {
+        drawProgressMarker(drawHelperProps);
+      }
+      if (shouldDrawAmplitudeWavelengthCaptions) {
+        // drawAmplitudeMarker(drawHelperProps);
+        drawSoundMarkers(drawHelperProps);
+      }
     } else {
       drawZoomAreaMarker(drawHelperProps);
     }

--- a/src/hooks/use-sound-wave-rendering.ts
+++ b/src/hooks/use-sound-wave-rendering.ts
@@ -138,7 +138,7 @@ const drawSoundMarkers = (props: IDrawHelperProps) => {
   ctx.fillStyle = "#303030";
   ctx.fillText(`Amplitude`, textLeftLocation, textBaselineYlocation);
 
-  // Draw the WAVELENGTH marker and label...
+  // Draw the WAVELENGTH label (ONLY, no marker line)...
 
   if (!pureToneFrequency) { return; }
 
@@ -158,54 +158,6 @@ const drawSoundMarkers = (props: IDrawHelperProps) => {
   ctx.fillText(`wavelength: ${wavelengthInMs.toPrecision(3)}ms`,
     wavelengthCaptionX + (wavelengthTextBoxWidth / 2) + (textPadding / 2),
     wavelengthCaptionY + (textBoxHeight / 2) + (textPadding / 2));
-
-  // Draw wavelength arrow
-  const timePerSampleinMs = 1000 / audioBuffer.sampleRate;
-  const samplesForOneWavelength = wavelengthInMs / timePerSampleinMs;
-
-  // console.log({pureToneFrequency},{wavelengthInMs});
-  // console.log({audioBuffer},{timePerSample: timePerSampleinMs},{samplesForOneWavelength})
-
-  // const currentDataPointIdx = getCurrentSampleIdx(props);
-  // const zoomedInViewPointsCount = getZoomedInViewPointsCount(props);
-  // const leftRightOffsetInSamples = (zoomedInViewPointsCount / 2);
-  // const leftRightOffsetInMilliseconds =
-  //   Math.round((timePerSample * leftRightOffsetInSamples) * 1000);
-  // const samplesInView = zoomedInViewPointsCount;
-  // const millisecondsInView =
-  //   Math.round((timePerSampleinMs * zoomedInViewSamplesCount) * 1000);
-
-  // const numberOfWavelengthsInView = millisecondsInView / wavelengthInMs;
-  // const pointsPerMillisecond = zoomedInViewSamplesCount / millisecondsInView;
-  // const pxPerWavelength = width / numberOfWavelengthsInView;
-  const pxPerWavelength = (samplesForOneWavelength * zoom);
-
-  // console.log({width},{pxPerWavelength})
-  // console.log({wavelengthInMs},{millisecondsInView});
-  // console.log({zoom},{numberOfWavelengthsInView});
-  // console.log({zoomedInViewPointsCount},{pointsPerMillisecond});
-
-  const arrowWidth = pxPerWavelength;
-  const arrowHeadWidth = 8;
-  const arrowHeadHeight = 3;
-  ctx.strokeStyle = "black";
-  ctx.fillRect(width / 2, (height / 2) - 1, arrowWidth, 2);
-  ctx.beginPath();
-  ctx.moveTo(width / 2, height / 2);
-  ctx.lineTo((width / 2) + arrowHeadWidth, (height / 2) + arrowHeadHeight);
-  ctx.stroke();
-  ctx.beginPath();
-  ctx.moveTo(width / 2, height / 2);
-  ctx.lineTo((width / 2) + arrowHeadWidth, (height / 2) - arrowHeadHeight);
-  ctx.stroke();
-  ctx.beginPath();
-  ctx.moveTo((width / 2) + arrowWidth, height / 2);
-  ctx.lineTo((width / 2) + arrowWidth - arrowHeadWidth, (height / 2) + arrowHeadHeight);
-  ctx.stroke();
-  ctx.beginPath();
-  ctx.moveTo((width / 2) + arrowWidth, height / 2);
-  ctx.lineTo((width / 2) + arrowWidth - arrowHeadWidth, (height / 2) - arrowHeadHeight);
-  ctx.stroke();
 };
 
 export const useSoundWaveRendering = (canvasRef: RefObject<HTMLCanvasElement>, data: Float32Array, props: ISoundWaveProps) => {

--- a/src/hooks/use-sound-wave-rendering.ts
+++ b/src/hooks/use-sound-wave-rendering.ts
@@ -13,7 +13,7 @@ const drawBackground = (props: IDrawHelperProps) => {
 };
 
 const drawTimeCaptions = (props: IDrawHelperProps) => {
-  const { ctx, width, height, zoomedInView, audioBuffer } = props;
+  const { ctx, width, height, audioBuffer } = props;
 
   // Need the audioBuffer to calculate
   if (!audioBuffer) { return; }
@@ -94,9 +94,10 @@ const drawZoomAreaMarker = (props: IDrawHelperProps) => {
 
 // Used only in the zoomed in view.
 const drawSoundMarkers = (props: IDrawHelperProps) => {
-  const { ctx, width, height, volume, zoomedInView } = props;
+  const { ctx, width, height, volume, zoomedInView, pureToneFrequency } = props;
 
-  // Draw AMPLITUDE marker
+  // Draw AMPLITUDE marker & label...
+
   const pointsCount = getPointsCount(props);
   const currentDataPointIdx = getCurrentSampleIdx(props);
   const zoomedInViewPointsCount = getZoomedInViewPointsCount(props);
@@ -116,7 +117,7 @@ const drawSoundMarkers = (props: IDrawHelperProps) => {
   // Ensure the Y coordinate is not negative, so that caption is visible
   const amplitudeCaptionY = Math.max(minAmplitude - (textBoxHeight), 0);
 
-console.log({captionY: amplitudeCaptionY},{volume},{height},{maxAmplitude: minAmplitude});
+// console.log({captionY: amplitudeCaptionY},{volume},{height},{maxAmplitude: minAmplitude});
 
   // Draw the text background's border
   // const borderWidth = 1;
@@ -142,18 +143,58 @@ console.log({captionY: amplitudeCaptionY},{volume},{height},{maxAmplitude: minAm
   ctx.fillStyle = "#303030";
   ctx.fillText(`Amplitude`, textLeftLocation, textBaselineYlocation);
 
+  if (!pureToneFrequency) { return; }
+  const wavelengthInMs = ((1 / pureToneFrequency) * 1000).toPrecision(3);
 
-// TODO: draw wavelength marker
+  // Draw the WAVELENGTH marker and label...
+  const wavelengthMargin = 0;
+  const wavelengthTextBoxWidth = 120;
+  const wavelengthCaptionX = (width / 2) + wavelengthMargin;
+  const wavelengthCaptionY = (height / 2) + wavelengthMargin;
 
-  // const { ctx, width, height } = props;
-  // ctx.font = "'Comfortaa', cursive";
-  // ctx.textAlign = "left";
-  // // ctx.fillText(`${timeIndexLeft} ms`, textLeftLocation, textBaselineYlocation);
+  // Draw (semi-opaque) background for the text
+  ctx.fillStyle = "#ffffffb0"; //"#f0f00080";
+  ctx.fillRect(wavelengthCaptionX, wavelengthCaptionY,
+  wavelengthTextBoxWidth, textBoxHeight);
 
+  // Draw label text
+  ctx.fillStyle = "#303030";
+  ctx.textAlign = "center";
+  ctx.fillText(`wavelength: ${wavelengthInMs}ms`,
+    wavelengthCaptionX + (wavelengthTextBoxWidth / 2) + (textPadding / 2),
+    wavelengthCaptionY + (textBoxHeight / 2) + (textPadding / 2));
+
+  // Draw wavelength arrow
+console.log({wavelengthInMs},{zoomedInViewPointsCount})
+  const arrowWidth = 35;
+  const arrowHeadWidth = 8;
+  const arrowHeadHeight = 3;
+  ctx.strokeStyle = "black";
+  ctx.fillRect(width / 2, (height / 2) - 1, arrowWidth, 2);
+
+  ctx.beginPath();
+  ctx.moveTo(width / 2, height / 2);
+  ctx.lineTo((width / 2) + arrowHeadWidth, (height / 2) + arrowHeadHeight);
+  ctx.stroke();
+
+  ctx.beginPath();
+  ctx.moveTo(width / 2, height / 2);
+  ctx.lineTo((width / 2) + arrowHeadWidth, (height / 2) - arrowHeadHeight);
+  ctx.stroke();
+
+  ctx.beginPath();
+  ctx.moveTo((width / 2) + arrowWidth, height / 2);
+  ctx.lineTo((width / 2) + arrowWidth - arrowHeadWidth, (height / 2) + arrowHeadHeight);
+  ctx.stroke();
+
+  ctx.beginPath();
+  ctx.moveTo((width / 2) + arrowWidth, height / 2);
+  ctx.lineTo((width / 2) + arrowWidth - arrowHeadWidth, (height / 2) - arrowHeadHeight);
+  ctx.stroke();
 };
 
 export const useSoundWaveRendering = (canvasRef: RefObject<HTMLCanvasElement>, data: Float32Array, props: ISoundWaveProps) => {
-  const { width, height, audioBuffer, volume, playbackProgress, zoom, zoomedInView, shouldDrawProgressMarker, shouldDrawAmplitudeWavelengthCaptions } = props;
+  const { width, height, audioBuffer, volume, playbackProgress, zoom, zoomedInView, shouldDrawProgressMarker, shouldDrawAmplitudeWavelengthCaptions, pureToneFrequency } = props;
 
   useEffect(() => {
     if (!canvasRef.current) {
@@ -168,7 +209,7 @@ export const useSoundWaveRendering = (canvasRef: RefObject<HTMLCanvasElement>, d
     }
     // Just to keep things simple, provide one props object to all the helpers.
     const drawHelperProps: IDrawHelperProps = {
-      ctx, width, height, audioBuffer, data, volume, playbackProgress, zoom, zoomedInView
+      ctx, width, height, audioBuffer, data, volume, playbackProgress, zoom, zoomedInView, pureToneFrequency
     };
 
     drawBackground(drawHelperProps);

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export interface ISoundWaveProps {
   interactive?: boolean;
   onProgressUpdate?: (newProgress: number) => void;
   shouldDrawProgressMarker?: boolean;
+  shouldDrawAmplitudeWavelengthCaptions?: boolean;
 }
 
 export interface IZoomButtonsProps {

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,7 @@ export interface ISoundWaveProps {
   interactive?: boolean;
   onProgressUpdate?: (newProgress: number) => void;
   shouldDrawProgressMarker?: boolean;
-  shouldDrawAmplitudeWavelengthCaptions?: boolean;
+  shouldDrawWaveCaptions?: boolean;
   pureToneFrequency?: number;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export interface ISoundWaveProps {
   onProgressUpdate?: (newProgress: number) => void;
   shouldDrawProgressMarker?: boolean;
   shouldDrawAmplitudeWavelengthCaptions?: boolean;
+  pureToneFrequency?: number;
 }
 
 export interface IZoomButtonsProps {


### PR DESCRIPTION
PT [Radio] Label wave story: https://www.pivotaltracker.com/story/show/179928016

Note: this is a feature meant for 'pure' (sinusoidal) sound selections, as the labels are not necessarily meaningful for non-sine wave sounds.

- Draws a vertical 'marker' line corresponding to the amplitude of the wave.
- Height of line varies proportionally with volume changes
- The vertical line has a text caption ("Amplitude") at its top (or at the top of graph, if amplitude exceeds the graph rendering limits)
- Adds a text caption ("wavelength") which spells out the period of the wave, in milliseconds (e.g., 2kHz wave --> 0.5ms period)
- UPDATE: the horizontal line, as seen in the screen shot is no longer part of this work (removed code due to un-resolved rendering issue).
- Allows user to control whether labels are drawn (or not) by clicking on the 'price tag' icon.
- Automatically hides labels, when a non-sine wave sound is selected; and visibly disables the icon.

<img width="390" alt="179928016-label-wave(WIP)" src="https://user-images.githubusercontent.com/91078832/142061562-01e00927-7cf0-4198-984d-a0019d2c020c.png">

