### PR TITLE
180792073 UI contrast

### DIFF
--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -5,7 +5,7 @@ HTML {
 }
 
 BODY {
-  background-color: $controlsBackground;
+  background-color: $applicationBackground;
   height: 100%;
 }
 
@@ -32,6 +32,7 @@ BODY {
     margin-bottom: -2px;
     height: 50px;
     padding: 4px 15px 2px 15px;
+    background-color: $controlsBackground;
     border: $borderWidth solid $darkBorderColor;
 
     .speed-label {
@@ -70,16 +71,14 @@ BODY {
   }
 
   .speed-slider.disabled {
-    .rc-slider-rail, .rc-slider-handle {
-      background-color: $disabledButton;
-      border-color: $disabledButton;
-    }
+    background-color: transparent;
   }
 
   .playback-and-volume-controls {
     margin: 0;
     margin-bottom: -2px;
     display: flex;
+    background-color: $controlsBackground;
     border: $borderWidth solid $darkBorderColor;
     border-top-left-radius: $borderRadius;
     border-top-right-radius: $borderRadius;
@@ -147,6 +146,14 @@ BODY {
     }
   }
 
+  .rc-slider-mark-text, .rc-slider-mark-text-active {
+    color: $controls;
+  }
+
+  .rc-slider-disabled .rc-slider-mark-text, .rc-slider-disabled .rc-slider-mark-text-active {
+    color: $disabledButton;
+  }
+
   .sound-wave-container {
     margin: 0;
   }
@@ -158,6 +165,7 @@ BODY {
     align-items: center;
     height: 60px;
     padding: 3px 5px 0 10px;
+    background-color: $controls;
 
     &.chosen-sound {
       border: $borderWidth solid $darkBorderColor;

--- a/src/components/application-header/application-header.scss
+++ b/src/components/application-header/application-header.scss
@@ -2,21 +2,11 @@
 
 .application-header-container {
     height: $applicationHeaderContainerHeight;
-    color: #fff;
-    background-color: #024059;
+    color: $controls;
+    background-color: $controlsBackground;
     font-size: 24px;
     line-height: 26px;
 
     display: flex;
     align-items: center;
-
-    svg {
-        width: 120px;
-        padding: 3px;
-        margin-right: 10px;
-
-        path, circle {
-        fill: #fff;
-        }
-    }
 }

--- a/src/components/carrier-wave/carrier-wave.scss
+++ b/src/components/carrier-wave/carrier-wave.scss
@@ -7,6 +7,7 @@
   color: $controls;
   border: 2px solid $darkBorderColor;
   border-radius: $borderRadius;
+  background-color: $controlsBackground;
 
   .carrier-picker-container {
     display: flex;
@@ -33,41 +34,13 @@
     }
 
     span.value {
-      color: #03478D;
+      color: $controls;
     }
   }
 
   DIV.zoomed-in-view {
     margin-bottom: 5px;
   }
-
-  // .zoomed-out-graph-container {
-  //   margin: 0;
-  //   margin-top: -6px;
-  //   display: flex;
-  //   align-items: center;
-  //   height: 60px;
-  //   padding: 3px 5px 0 10px;
-
-  //   .zoom-buttons-container {
-  //     // width: 130px;
-  //     margin-top: -5px;
-  //     display: flex;
-  //     align-items: center;
-  //     justify-content: space-around;
-
-  //     .zoom-button {
-  //       width: 48px;
-  //       height: 48px;
-  //       cursor: pointer;
-  //       background-color: $controls;
-  //       border-radius: 15px;
-  //       svg {
-  //         fill: white
-  //       }
-  //     }
-  //   }
-  // }
 
   DIV.freq-mod-container {
     margin-top: 1px;

--- a/src/components/sound-picker/sound-picker.scss
+++ b/src/components/sound-picker/sound-picker.scss
@@ -14,9 +14,7 @@
     .sound-picker {
       font-size: $selectFontSize;
       width: 100%;
-      color: $controls;
       border-color: $darkBorderColor;
-      background-color: $controlsBackgroundSolid;
       }
   }
 

--- a/src/components/sound-wave.scss
+++ b/src/components/sound-wave.scss
@@ -14,6 +14,7 @@
 
   &.zoomed-in-view canvas {
     background-color: $graphBackgroundColor;
+    border-color: #ea6d2f;
   }
 
   .frequency {

--- a/src/components/sound-wave.scss
+++ b/src/components/sound-wave.scss
@@ -14,7 +14,7 @@
 
   &.zoomed-in-view canvas {
     background-color: $graphBackgroundColor;
-    border-color: #ea6d2f;
+    border-color: $waveGraphMarker;
   }
 
   .frequency {

--- a/src/components/vars.scss
+++ b/src/components/vars.scss
@@ -1,3 +1,4 @@
+$applicationBackground: white;
 $applicationHeaderContainerHeight: 50px;
 $soundPickerContainerHeight: 30px;
 $soundWaveContainerHeight: 270px;
@@ -11,8 +12,8 @@ $smallLabelFontSize: 70%;
 $darkGray: #494949;
 $borderColor: #e0e0e0;
 $darkBorderColor: #d0d0ff;
-$controls: #3377BD;
-$controlsBackground: #3377BD20;
+$controls: white;
+$controlsBackground: #024059; /* #3377BD;*/
 $controlsBackgroundSolid: #ffffff20;
 $disabledButton: #aaa;
 

--- a/src/components/vars.scss
+++ b/src/components/vars.scss
@@ -13,9 +13,10 @@ $darkGray: #494949;
 $borderColor: #e0e0e0;
 $darkBorderColor: #d0d0ff;
 $controls: white;
-$controlsBackground: #024059; /* #3377BD;*/
+$controlsBackground: #024059;
 $controlsBackgroundSolid: #ffffff20;
 $disabledButton: #aaa;
+$waveGraphMarker: #ea6d2f;
 
 $graphBackgroundColor: white;
 $zoomedOutGraphBackgroundColor: #F0F0F0;

--- a/src/components/zoom-buttons/zoom-buttons.scss
+++ b/src/components/zoom-buttons/zoom-buttons.scss
@@ -11,9 +11,9 @@
   width: 48px;
   height: 48px;
   cursor: pointer;
-  background-color: $controls;
+  background-color: $controlsBackground;
   border-radius: 15px;
   svg {
-    fill: white
+    fill: $controls;
   }
 }

--- a/src/hooks/use-sound-wave-rendering.ts
+++ b/src/hooks/use-sound-wave-rendering.ts
@@ -69,7 +69,7 @@ const drawProgressMarker = (props: IDrawHelperProps) => {
   const markerX = Math.round(width * 0.5);
   const markerY = getCurrentAmplitudeY(props, getCurrentSampleIdx(props));
 
-  ctx.fillStyle = "#88D3DD";
+  ctx.fillStyle = "#ea6d2f";
   ctx.fillRect(markerX, 0, 1, height); // line
   ctx.beginPath();
   ctx.arc(markerX, markerY, 5, 0, 2 * Math.PI); // dot
@@ -85,10 +85,17 @@ const drawZoomAreaMarker = (props: IDrawHelperProps) => {
   const xScale = width / pointsCount;
   const markerWidth = (zoomedInViewPointsCount / pointsCount) * width;
 
-  ctx.strokeStyle = "#333";
+  // Marker border
+  ctx.strokeStyle = "#ea6d2f";
   ctx.lineWidth = 2;
   ctx.strokeRect(x * xScale, 0, markerWidth, height);
-  ctx.fillStyle = "#88D3DDFF";
+
+  // Marker area highlight
+  ctx.fillStyle = "#ea6d2f40";
+  ctx.fillRect( (x * xScale) + 2 , 2, markerWidth - 4, height -4);
+
+  // Marker center hairline
+  ctx.fillStyle = "#ea6d2f80";
   ctx.fillRect(x * xScale + 0.5 * markerWidth, 0, 1, height); // line
 };
 


### PR DESCRIPTION
Ticket: https://www.pivotaltracker.com/story/show/180792073

Changes color scheme, per ticket:
Text color, control color, background color for controls/control areas (Carrier Wave choice, Speed, Volume, etc.)
Also to screen/page background
'Marker' region (both overall view, and zoomed-in view) for indicating current playback point (and zoomed-in view region): changed color scheme to orange, and also added a cursor line to the horizontal center of the marker.

N.B. overall layout changes, different controls, border changes, etc. will be worked on during other tickets, and are out of scope here.

<img width="599" alt="Screen Shot 2022-01-06 at 2 11 13 PM" src="https://user-images.githubusercontent.com/91078832/148439335-2e95628b-1f40-445b-80bf-8bdcb90c5536.png">

