### PR TITLE
180792088 move zoom controls

### DIFF
--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -159,23 +159,23 @@ BODY {
   }
 
   .zoomed-out-graph-container {
-    margin: 0;
-    margin-top: -11px;
-    display: flex;
-    align-items: center;
+    // margin: 0;
+    // margin-top: -11px;
+    // display: flex;
+    // align-items: center;
     height: 60px;
-    padding: 3px 5px 0 10px;
+    // padding: 3px 5px 0 10px;
     background-color: $controls;
 
-    &.chosen-sound {
-      border: $borderWidth solid $darkBorderColor;
-      border-bottom-left-radius: $borderRadius;
-      border-bottom-right-radius: $borderRadius;
-    }
+    // &.chosen-sound {
+    //   border: $borderWidth solid $darkBorderColor;
+    //   border-bottom-left-radius: $borderRadius;
+    //   border-bottom-right-radius: $borderRadius;
+    // }
 
-    &.chosen-carrier {
-      border-bottom: $borderWidth solid $darkBorderColor;
-    }
+    // &.chosen-carrier {
+    //   border-bottom: $borderWidth solid $darkBorderColor;
+    // }
   }
 } // END OF: .app
 

--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -159,23 +159,8 @@ BODY {
   }
 
   .zoomed-out-graph-container {
-    // margin: 0;
-    // margin-top: -11px;
-    // display: flex;
-    // align-items: center;
-    height: 60px;
-    // padding: 3px 5px 0 10px;
+    height: 40px;
     background-color: $controls;
-
-    // &.chosen-sound {
-    //   border: $borderWidth solid $darkBorderColor;
-    //   border-bottom-left-radius: $borderRadius;
-    //   border-bottom-right-radius: $borderRadius;
-    // }
-
-    // &.chosen-carrier {
-    //   border-bottom: $borderWidth solid $darkBorderColor;
-    // }
   }
 } // END OF: .app
 

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -259,10 +259,13 @@ export const App = () => {
             shouldDrawProgressMarker={true}
             shouldDrawWaveCaptions={!playing && isPureTone(selectedSound) && drawWaveLabels}
             pureToneFrequency={pureToneFrequencyFromSoundName(selectedSound)}
-          />
+            handleZoomIn={handleZoomIn}
+            handleZoomOut={handleZoomOut}
+        />
+          {/* <ZoomButtons handleZoomIn={handleZoomIn} handleZoomOut={handleZoomOut} /> */}
           <div className="zoomed-out-graph-container chosen-sound">
             <SoundWave
-              width={graphWidth - ZOOM_BUTTONS_WIDTH}
+              width={graphWidth}
               height={ZOOMED_OUT_GRAPH_HEIGHT}
               audioBuffer={audioBuffer}
               volume={volume}
@@ -272,7 +275,6 @@ export const App = () => {
               interactive={!playing}
               onProgressUpdate={handleProgressUpdate}
             />
-            <ZoomButtons handleZoomIn={handleZoomIn} handleZoomOut={handleZoomOut} />
           </div>
         </div>
       </div>

--- a/src/components/carrier-wave/carrier-wave.scss
+++ b/src/components/carrier-wave/carrier-wave.scss
@@ -20,7 +20,6 @@
   }
 
   .carrier-wave-graph-container {
-    height:  180px;
     margin: 5px 0 5px -2px;
   }
 
@@ -36,10 +35,6 @@
     span.value {
       color: $controls;
     }
-  }
-
-  DIV.zoomed-in-view {
-    margin-bottom: 5px;
   }
 
   DIV.freq-mod-container {

--- a/src/components/carrier-wave/carrier-wave.scss
+++ b/src/components/carrier-wave/carrier-wave.scss
@@ -29,7 +29,7 @@
       font-size: $selectFontSize;
       color: $controls;
       border-color: $darkBorderColor;
-      background-color: $controlsBackgroundSolid;
+      background-color: $controlsBackgroundSemiTransparent;
     }
 
     span.value {

--- a/src/components/carrier-wave/carrier-wave.tsx
+++ b/src/components/carrier-wave/carrier-wave.tsx
@@ -103,11 +103,14 @@ export const CarrierWave = (props: ICarrierWaveProps) => {
             shouldDrawProgressMarker={(modulation !== "")}
             pureToneFrequency={carrierFrequency}
             interactive={false}
+            handleZoomIn={handleZoomIn}
+            handleZoomOut={handleZoomOut}
           />
         </div>
+        {/* <ZoomButtons handleZoomIn={handleZoomIn} handleZoomOut={handleZoomOut} /> */}
         <div className="zoomed-out-graph-container chosen-carrier">
           <SoundWave
-            width={graphWidth - ZOOM_BUTTONS_WIDTH}
+            width={graphWidth}
             height={ZOOMED_OUT_GRAPH_HEIGHT}
             audioBuffer={carrierBuffer}
             volume={modulation === "AM" ? volume : 1}
@@ -117,7 +120,6 @@ export const CarrierWave = (props: ICarrierWaveProps) => {
             interactive={interactive}
             onProgressUpdate={onProgressUpdate}
           />
-          <ZoomButtons handleZoomIn={handleZoomIn} handleZoomOut={handleZoomOut} />
         </div>
       </div>
       <div className="wavelength-mod-container">

--- a/src/components/sound-wave.tsx
+++ b/src/components/sound-wave.tsx
@@ -3,13 +3,15 @@ import { useSoundWaveInteractions } from "../hooks/use-sound-wave-interactions";
 import { useSoundWaveRendering } from "../hooks/use-sound-wave-rendering";
 import { ISoundWaveProps } from "../types";
 import { downsampleAudioBuffer } from "../utils/audio";
+import { ZoomButtons } from "./zoom-buttons/zoom-buttons";
+
 import "./sound-wave.scss";
 
 // Performance - 20k seems to be reasonable limit (tested on desktop Chrome, Safari and iOS Safari)
 const MAX_GRAPH_POINTS = 20000;
 
 export const SoundWave = (props: ISoundWaveProps) => {
-  const { interactive, audioBuffer, zoom, zoomedInView, shouldDrawWaveCaptions, pureToneFrequency } = props;
+  const { interactive, audioBuffer, zoom, zoomedInView, shouldDrawWaveCaptions, pureToneFrequency, handleZoomIn, handleZoomOut } = props;
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [data, setData] = useState<Float32Array>(new Float32Array(0));
 
@@ -47,6 +49,10 @@ export const SoundWave = (props: ISoundWaveProps) => {
         onPointerDown={interactive ? handlePointerDown : undefined}
         onPointerMove={interactive ? handlePointerMove : undefined}
       />
+      {
+        zoomedInView &&
+          <ZoomButtons handleZoomIn={handleZoomIn} handleZoomOut={handleZoomOut}/>
+      }
     </div>
   );
 };

--- a/src/components/vars.scss
+++ b/src/components/vars.scss
@@ -14,7 +14,10 @@ $borderColor: #e0e0e0;
 $darkBorderColor: #d0d0ff;
 $controls: white;
 $controlsBackground: #024059;
-$controlsBackgroundSolid: #ffffff20;
+$controlsAlternateBackground: #3377BD;
+$controlsBackgroundSemiTransparent: #ffffff20;
+$zoomControlsContainerBackground: #ffffffb0;
+$zoomControlsContainerBorder: #3377BDe0;
 $disabledButton: #aaa;
 $waveGraphMarker: #ea6d2f;
 

--- a/src/components/zoom-buttons/zoom-buttons.scss
+++ b/src/components/zoom-buttons/zoom-buttons.scss
@@ -5,22 +5,23 @@
   position: absolute;
   top: 2px;
   left: 2px;
-  width: 130px;
+  width: 110px;
   display: flex;
   align-items: center;
   justify-content: space-around;
+  background-color: $zoomControlsContainerBackground;
+  border: 1px solid $zoomControlsContainerBorder;
 }
 
 .zoom-button-container {
   padding: 3px;
-  border: 3px solid $controlsBackground;
 }
 
 .zoom-button {
   width: 48px;
   height: 48px;
   cursor: pointer;
-  background-color: $controlsBackground;
+  background-color: $controlsAlternateBackground;
   border-radius: 12px;
   svg {
     fill: $controls;

--- a/src/components/zoom-buttons/zoom-buttons.scss
+++ b/src/components/zoom-buttons/zoom-buttons.scss
@@ -2,8 +2,8 @@
 
 .zoom-buttons-container {
   z-index: 2;
-  position: relative;
-  top: -108px;
+  position: absolute;
+  top: 2px;
   left: 2px;
   width: 130px;
   display: flex;

--- a/src/components/zoom-buttons/zoom-buttons.scss
+++ b/src/components/zoom-buttons/zoom-buttons.scss
@@ -5,25 +5,26 @@
   position: absolute;
   top: 2px;
   left: 2px;
-  width: 110px;
+  width: 30px;
+  height: 54px;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: space-around;
+  padding: 2px 0px;
   background-color: $zoomControlsContainerBackground;
   border: 1px solid $zoomControlsContainerBorder;
 }
 
-.zoom-button-container {
-  padding: 3px;
-}
-
 .zoom-button {
-  width: 48px;
-  height: 48px;
+  height: 24px;
+  width: 24px;
   cursor: pointer;
   background-color: $controlsAlternateBackground;
-  border-radius: 12px;
+  border-radius: 6px;
   svg {
     fill: $controls;
+    height: 24px;
+    width: 24px;
   }
 }

--- a/src/components/zoom-buttons/zoom-buttons.scss
+++ b/src/components/zoom-buttons/zoom-buttons.scss
@@ -1,10 +1,19 @@
 @import "../vars.scss";
 
 .zoom-buttons-container {
+  z-index: 2;
+  position: relative;
+  top: -108px;
+  left: 2px;
   width: 130px;
   display: flex;
   align-items: center;
   justify-content: space-around;
+}
+
+.zoom-button-container {
+  padding: 3px;
+  border: 3px solid $controlsBackground;
 }
 
 .zoom-button {
@@ -12,7 +21,7 @@
   height: 48px;
   cursor: pointer;
   background-color: $controlsBackground;
-  border-radius: 15px;
+  border-radius: 12px;
   svg {
     fill: $controls;
   }

--- a/src/components/zoom-buttons/zoom-buttons.tsx
+++ b/src/components/zoom-buttons/zoom-buttons.tsx
@@ -12,17 +12,22 @@ export const ZoomButtons = (props: IZoomButtonsProps) => {
     <div
       className="zoom-buttons-container"
     >
-      <div
-        className="zoom-button"
-        onClick={handleZoomOut}
-      >
-        <MinusIcon />
+      <div className="zoom-button-container">
+        <div
+          className="zoom-button"
+          onClick={handleZoomOut}
+        >
+          <MinusIcon />
+        </div>
       </div>
-      <div
-        className="zoom-button"
-        onClick={handleZoomIn}
-      >
-        <PlusIcon />
+
+      <div className="zoom-button-container">
+        <div
+          className="zoom-button"
+          onClick={handleZoomIn}
+        >
+          <PlusIcon />
+        </div>
       </div>
     </div>
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ const SIDE_MARGIN = 8; // Units: px. If changing; also change $margin, in vars.s
 const BORDER_WIDTH = 2; // Units: px; If changing; also change: $borderWidth, in vars.scss
 export const SIDE_MARGIN_PLUS_BORDER = SIDE_MARGIN + BORDER_WIDTH; // Units: px;
 export const SOUND_WAVE_GRAPH_HEIGHT = 105;
-export const ZOOMED_OUT_GRAPH_HEIGHT = 45;
+export const ZOOMED_OUT_GRAPH_HEIGHT = 35;
 
 // Arbitrary value (in Hz) -- but it needs to be in the valid range, per the API specification.
 // Note: the specification requires browsers to support a range of, at least: 8000..96000
@@ -24,6 +24,8 @@ export interface ISoundWaveProps {
   shouldDrawProgressMarker?: boolean;
   shouldDrawWaveCaptions?: boolean;
   pureToneFrequency?: number;
+  handleZoomOut?: () => void;
+  handleZoomIn?: () => void;
 }
 
 export interface IZoomButtonsProps {


### PR DESCRIPTION
Ticket: https://www.pivotaltracker.com/story/show/180792088
Requirements:
As Museum Docent, I want to use most vertical space for graphs, and emphasize full width as the time axis.
- move zoom controls to upper left corner of zoomed graph displays (signal and modulated)
- shorten the height of full signal view and lengthen the width to the same as the zoomed signal graph
And how it looks now:
<img width="523" alt="Screen Shot 2022-01-10 at 11 17 15 AM" src="https://user-images.githubusercontent.com/91078832/148803808-48244dac-877c-4bca-90ee-bbb963f7babc.png">

