### PR TITLE
180792001 refactor record button

### DIFF
--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -5,7 +5,7 @@ HTML {
 }
 
 BODY {
-  background-color: $applicationBackground;
+  background-color: $applicationBackgroundColor;
   height: 100%;
 }
 
@@ -32,17 +32,17 @@ BODY {
     margin-bottom: -2px;
     height: 50px;
     padding: 4px 15px 2px 15px;
-    background-color: $controlsBackground;
+    background-color: $controlsBackgroundColor;
     border: $borderWidth solid $darkBorderColor;
 
     .speed-label {
       margin-bottom: 5px;
       text-align: center;
       font-size: $smallLabelFontSize;
-      color: $controls;
+      color: $controlsColor;
 
       &.disabled {
-        color: $disabledButton;
+        color: $disabledButtonColor;
       }
     }
   }
@@ -50,20 +50,20 @@ BODY {
   .speed-slider {
     width: 100%;
     .rc-slider-track {
-      background-color: $controls;
+      background-color: $controlsColor;
       height: 6px;
     }
     .rc-slider-rail {
-      background-color: $controls;
+      background-color: $controlsColor;
       height: 6px;
     }
     .rc-slider-handle {
-      fill: $controls;
+      fill: $controlsColor;
       height: 20px;
       width: 20px;
       margin-top: -7px;
-      border-color: $controls;
-      background-color: $controls;
+      border-color: $controlsColor;
+      background-color: $controlsColor;
       &:active, &:hover {
         box-shadow: none;
       }
@@ -78,7 +78,7 @@ BODY {
     margin: 0;
     margin-bottom: -2px;
     display: flex;
-    background-color: $controlsBackground;
+    background-color: $controlsBackgroundColor;
     border: $borderWidth solid $darkBorderColor;
     border-top-left-radius: $borderRadius;
     border-top-right-radius: $borderRadius;
@@ -88,12 +88,12 @@ BODY {
       margin-right: 2px;
 
       &.disabled > svg {
-        fill: $disabledButton;
+        fill: $disabledButtonColor;
         cursor: default;
       }
 
       .pause-play-icons {
-        fill: $controls;
+        fill: $controlsColor;
       }
     }
 
@@ -103,7 +103,7 @@ BODY {
       cursor: pointer;
 
       &.disabled {
-        fill: $disabledButton;
+        fill: $disabledButtonColor;
         cursor: default;
       }
     }
@@ -120,7 +120,7 @@ BODY {
       .volume-icon {
         height: 48px;
         width: 48px;
-        fill: $controls;
+        fill: $controlsColor;
       }
 
       .volume-slider-container {
@@ -131,19 +131,19 @@ BODY {
       .volume-slider {
         width: 60%;
         .rc-slider-track {
-          background-color: $controls;
+          background-color: $controlsColor;
           height: 6px;
         }
         .rc-slider-rail {
-          background-color: $controls;
+          background-color: $controlsColor;
           height: 6px;
         }
         .rc-slider-handle {
           height: 20px;
           width: 20px;
           margin-top: -7px;
-          border-color: $controls;
-          background-color: $controls;
+          border-color: $controlsColor;
+          background-color: $controlsColor;
           &:active, &:hover {
             box-shadow: none;
           }
@@ -153,11 +153,11 @@ BODY {
   }
 
   .rc-slider-mark-text, .rc-slider-mark-text-active {
-    color: $controls;
+    color: $controlsColor;
   }
 
   .rc-slider-disabled .rc-slider-mark-text, .rc-slider-disabled .rc-slider-mark-text-active {
-    color: $disabledButton;
+    color: $disabledButtonColor;
   }
 
   .sound-wave-container {
@@ -166,7 +166,7 @@ BODY {
 
   .zoomed-out-graph-container {
     height: 40px;
-    background-color: $controls;
+    background-color: $controlsColor;
   }
 } // END OF: .app
 

--- a/src/components/app.scss
+++ b/src/components/app.scss
@@ -82,10 +82,19 @@ BODY {
     border: $borderWidth solid $darkBorderColor;
     border-top-left-radius: $borderRadius;
     border-top-right-radius: $borderRadius;
-    padding: 4px 10px 0px 5px;
+    padding: 4px 2px 0px 2px;
 
-    * {
-      fill: $controls;
+    .play-pause {
+      margin-right: 2px;
+
+      &.disabled > svg {
+        fill: $disabledButton;
+        cursor: default;
+      }
+
+      .pause-play-icons {
+        fill: $controls;
+      }
     }
 
     .button {
@@ -101,20 +110,17 @@ BODY {
 
     .volume-controls {
       width: 100%;
-      margin-left: 6px;
+      margin-left: 10px;
       display: flex;
 
       & > * {
         margin: 0;
       }
 
-      .play-pause {
-        margin-right: 2px;
-      }
-
       .volume-icon {
         height: 48px;
         width: 48px;
+        fill: $controls;
       }
 
       .volume-slider-container {
@@ -123,7 +129,7 @@ BODY {
       }
 
       .volume-slider {
-        width: 40%;
+        width: 60%;
         .rc-slider-track {
           background-color: $controls;
           height: 6px;

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -5,7 +5,7 @@ import { SIDE_MARGIN_PLUS_BORDER, SoundName, SOUND_WAVE_GRAPH_HEIGHT, ZOOMED_OUT
 import { SoundWave } from "./sound-wave";
 import { CarrierWave } from "./carrier-wave/carrier-wave";
 import { AppHeader } from "./application-header/application-header";
-import { SoundPicker, isPureTone, pureToneFrequencyFromSoundName } from "./sound-picker/sound-picker";
+import { SoundPicker, pureToneFrequencyFromSoundName } from "./sound-picker/sound-picker";
 import { useAutoWidth } from "../hooks/use-auto-width";
 
 import "./app.scss";

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -38,7 +38,9 @@ const sounds: Record<SoundName, string> = {
 
 export const App = () => {
   const [selectedSound, setSelectedSound] = useState<SoundName>("middle-c");
-  const [drawWaveLabels, setDrawWaveLabels] = useState<boolean>(false);
+  // -- commented out, but deliberately not removed, per: PT #180792001
+  // const [drawWaveLabels, setDrawWaveLabels] = useState<boolean>(false);
+  const drawWaveLabels = false;
   const [playing, setPlaying] = useState<boolean>(false);
   const [volume, setVolume] = useState<number>(1);
   const [zoom, setZoom] = useState<number>(16);
@@ -47,7 +49,7 @@ export const App = () => {
   const [graphWidth, setGraphWidth] = useState<number>(100);
   const [audioBuffer, setAudioBuffer] = useState<AudioBuffer>();
   const [recordingAudioBuffer, setRecordingAudioBuffer] =
-    useState<AudioBuffer>(new AudioBuffer({length: 3000, sampleRate: 3000}));
+    useState<AudioBuffer>(new AudioBuffer({length: 5 * SOUND_SAMPLE_RATE, sampleRate: SOUND_SAMPLE_RATE}));
 
   const audioContext = useRef<AudioContext>();
   const audioSource = useRef<AudioBufferSourceNode>();
@@ -115,6 +117,7 @@ console.log("Getting 'canned' sound...");
 console.log("useEffect()", {selectedSound});
     setupAudioContext(selectedSound);
   }, [selectedSound]);
+  // }, [selectedSound, setupAudioContext]);
 
   useEffect(() => {
     if (gainNode.current) {

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -46,6 +46,8 @@ export const App = () => {
   const [playbackRate, setPlaybackRate] = useState<number>(1);
   const [graphWidth, setGraphWidth] = useState<number>(100);
   const [audioBuffer, setAudioBuffer] = useState<AudioBuffer>();
+  const [recordingAudioBuffer, setRecordingAudioBuffer] =
+    useState<AudioBuffer>(new AudioBuffer({length: 3000, sampleRate: 3000}));
 
   const audioContext = useRef<AudioContext>();
   const audioSource = useRef<AudioBufferSourceNode>();
@@ -61,6 +63,7 @@ export const App = () => {
   });
 
   const setupAudioContextFromRecording = (recordingBuffer: AudioBuffer) => {
+console.log("setupAudioContextFromRecording");
     setAudioBuffer(recordingBuffer);
     setPlaybackProgress(0);
   };
@@ -76,19 +79,26 @@ export const App = () => {
     // immediately. But we do want to clear out the old sound data here, and to
     // update the playback progress indicator, so that it is clear that there
     // is nothing recorded (yet).
+console.log("setupAudioContext", {soundName});
     if (soundName === "record-my-own") {
-      const emptyBuffer = new AudioBuffer({
-        length: 1,
-        sampleRate: SOUND_SAMPLE_RATE
-      });
+console.log("setupAudioContext(), soundName is: 'record-my-own'");
+      // const emptyBuffer = new AudioBuffer({
+      //   length: 1,
+      //   sampleRate: SOUND_SAMPLE_RATE
+      // });
+      // audioContext.current = new AudioContext();
+      // gainNode.current = audioContext.current.createGain();
+      // setAudioBuffer(emptyBuffer);
       audioContext.current = new AudioContext();
       gainNode.current = audioContext.current.createGain();
-      setAudioBuffer(emptyBuffer);
+      setAudioBuffer(recordingAudioBuffer);
+
       setPlaybackProgress(0);
       return;
     }
 
     // Handle selection of 'canned' sounds...
+console.log("Getting 'canned' sound...");
     const response = await window.fetch(sounds[soundName]);
     const soundArrayBuffer = await response.arrayBuffer();
     audioContext.current = new AudioContext();
@@ -102,7 +112,7 @@ export const App = () => {
     // AudioContext is apparently unavailable in the node / jest environment.
     // So we bail out early, to prevent render test failure.
     if (!window.AudioContext) { return; }
-
+console.log("useEffect()", {selectedSound});
     setupAudioContext(selectedSound);
   }, [selectedSound]);
 
@@ -203,11 +213,14 @@ export const App = () => {
       <AppHeader />
       <SoundPicker
         selectedSound={selectedSound}
+        setSelectedSound={setSelectedSound}
+        recordingAudioBuffer={recordingAudioBuffer}
+        setRecordingAudioBuffer={setRecordingAudioBuffer}
         drawWaveLabels={drawWaveLabels}
         playing={playing}
         handleSoundChange={handleSoundChange}
         handleDrawWaveLabelChange={handleDrawWaveLabelChange}
-        onRecordingCompleted={setupAudioContextFromRecording}
+        onMyRecordingChosen={setupAudioContextFromRecording}
       />
       <div className="main-controls-and-waves-container">
         <div className="playback-and-volume-controls">

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -39,9 +39,6 @@ const sounds: Record<SoundName, string> = {
 
 export const App = () => {
   const [selectedSound, setSelectedSound] = useState<SoundName>("pick-sound");
-  // -- commented out, but deliberately not removed, per: PT #180792001
-  // const [drawWaveLabels, setDrawWaveLabels] = useState<boolean>(false);
-  const drawWaveLabels = false;
   const [playing, setPlaying] = useState<boolean>(false);
   const [volume, setVolume] = useState<number>(1);
   const [zoom, setZoom] = useState<number>(16);
@@ -107,12 +104,13 @@ export const App = () => {
     setPlaybackProgress(0);
   };
 
-    useEffect(() => {
+  useEffect(() => {
     // AudioContext is apparently unavailable in the node / jest environment.
     // So we bail out early, to prevent render test failure.
     if (!window.AudioContext) { return; }
     setupAudioContext(selectedSound);
   },
+    // Not including setupAudioContext() in dependency array; to avoid render loop.
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [selectedSound]
   );
@@ -122,11 +120,6 @@ export const App = () => {
       gainNode.current.gain.value = volume;
     }
   }, [volume]);
-
-  const handleDrawWaveLabelChange = () => {
-    // -- commented out, but deliberately not removed, per: PT #180792001
-    // setDrawWaveLabels(!drawWaveLabels);
-  };
 
   const handleVolumeChange = (value: number) => {
     setVolume(value);
@@ -215,20 +208,19 @@ export const App = () => {
         setSelectedSound={setSelectedSound}
         recordingAudioBuffer={recordingAudioBuffer}
         setRecordingAudioBuffer={setRecordingAudioBuffer}
-        drawWaveLabels={drawWaveLabels}
         playing={playing}
-        handleDrawWaveLabelChange={handleDrawWaveLabelChange}
         onMyRecordingChosen={setupAudioContextFromRecording}
       />
       <div className="main-controls-and-waves-container">
         <div className="playback-and-volume-controls">
           <div
             className={`play-pause button${(selectedSound === "pick-sound") ? " disabled" : ""}`}
-            onClick={handlePlay}>
-              { playing
-                ? <PauseIcon className="pause-play-icons" />
-                : <PlayIcon className="pause-play-icons" />
-              }
+            onClick={handlePlay}
+            >
+            { playing
+              ? <PauseIcon className="pause-play-icons" />
+              : <PlayIcon className="pause-play-icons" />
+            }
           </div>
           <div className="volume-controls">
             <div>
@@ -274,7 +266,6 @@ export const App = () => {
             zoom={zoom}
             zoomedInView={true}
             shouldDrawProgressMarker={true}
-            shouldDrawWaveCaptions={!playing && isPureTone(selectedSound) && drawWaveLabels}
             pureToneFrequency={pureToneFrequencyFromSoundName(selectedSound)}
             handleZoomIn={handleZoomIn}
             handleZoomOut={handleZoomOut}
@@ -301,7 +292,6 @@ export const App = () => {
         volume={volume}
         interactive={!playing}
         onProgressUpdate={handleProgressUpdate}
-        shouldDrawWaveCaptions={isPureTone(selectedSound) && drawWaveLabels}
       />
     </div>
   );

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -119,7 +119,8 @@ export const App = () => {
   };
 
   const handleDrawWaveLabelChange = () => {
-    setDrawWaveLabels(!drawWaveLabels);
+    // -- commented out, but deliberately not removed, per: PT #180792001
+    // setDrawWaveLabels(!drawWaveLabels);
   };
 
   const handleVolumeChange = (value: number) => {

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -65,7 +65,6 @@ export const App = () => {
   });
 
   const setupAudioContextFromRecording = (recordingBuffer: AudioBuffer) => {
-console.log("setupAudioContextFromRecording");
     setAudioBuffer(recordingBuffer);
     setPlaybackProgress(0);
   };
@@ -81,9 +80,7 @@ console.log("setupAudioContextFromRecording");
     // immediately. But we do want to clear out the old sound data here, and to
     // update the playback progress indicator, so that it is clear that there
     // is nothing recorded (yet).
-console.log("setupAudioContext", {soundName});
     if (soundName === "record-my-own") {
-console.log("setupAudioContext(), soundName is: 'record-my-own'");
       // const emptyBuffer = new AudioBuffer({
       //   length: 1,
       //   sampleRate: SOUND_SAMPLE_RATE
@@ -100,7 +97,6 @@ console.log("setupAudioContext(), soundName is: 'record-my-own'");
     }
 
     // Handle selection of 'canned' sounds...
-console.log("Getting 'canned' sound...");
     const response = await window.fetch(sounds[soundName]);
     const soundArrayBuffer = await response.arrayBuffer();
     audioContext.current = new AudioContext();
@@ -110,14 +106,13 @@ console.log("Getting 'canned' sound...");
     setPlaybackProgress(0);
   };
 
-  useEffect(() => {
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    useEffect(() => {
     // AudioContext is apparently unavailable in the node / jest environment.
     // So we bail out early, to prevent render test failure.
     if (!window.AudioContext) { return; }
-console.log("useEffect()", {selectedSound});
     setupAudioContext(selectedSound);
   }, [selectedSound]);
-  // }, [selectedSound, setupAudioContext]);
 
   useEffect(() => {
     if (gainNode.current) {

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -1,7 +1,7 @@
-import React, { ChangeEvent, useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import Slider from "rc-slider";
 
-import { SIDE_MARGIN_PLUS_BORDER, SoundName, SOUND_WAVE_GRAPH_HEIGHT, ZOOMED_OUT_GRAPH_HEIGHT, SOUND_SAMPLE_RATE } from "../types";
+import { SIDE_MARGIN_PLUS_BORDER, SoundName, SOUND_WAVE_GRAPH_HEIGHT, ZOOMED_OUT_GRAPH_HEIGHT } from "../types";
 import { SoundWave } from "./sound-wave";
 import { CarrierWave } from "./carrier-wave/carrier-wave";
 import { AppHeader } from "./application-header/application-header";
@@ -107,13 +107,15 @@ export const App = () => {
     setPlaybackProgress(0);
   };
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     useEffect(() => {
     // AudioContext is apparently unavailable in the node / jest environment.
     // So we bail out early, to prevent render test failure.
     if (!window.AudioContext) { return; }
     setupAudioContext(selectedSound);
-  }, [selectedSound]);
+  },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selectedSound]
+  );
 
   useEffect(() => {
     if (gainNode.current) {

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -48,8 +48,7 @@ export const App = () => {
   const [playbackRate, setPlaybackRate] = useState<number>(1);
   const [graphWidth, setGraphWidth] = useState<number>(100);
   const [audioBuffer, setAudioBuffer] = useState<AudioBuffer>();
-  const [recordingAudioBuffer, setRecordingAudioBuffer] =
-    useState<AudioBuffer>(new AudioBuffer({length: 5 * SOUND_SAMPLE_RATE, sampleRate: SOUND_SAMPLE_RATE}));
+  const [recordingAudioBuffer, setRecordingAudioBuffer] = useState<AudioBuffer>();
 
   const audioContext = useRef<AudioContext>();
   const audioSource = useRef<AudioBufferSourceNode>();

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -205,6 +205,7 @@ export const App = () => {
       <SoundPicker
         selectedSound={selectedSound}
         drawWaveLabels={drawWaveLabels}
+        playing={playing}
         handleSoundChange={handleSoundChange}
         handleDrawWaveLabelChange={handleDrawWaveLabelChange}
         onRecordingCompleted={setupAudioContextFromRecording}

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -43,7 +43,7 @@ const setupAudioContext = async (
   setPlaying: React.Dispatch<React.SetStateAction<boolean>>,
   gainNode: React.MutableRefObject<GainNode | undefined>,
   setAudioBuffer: React.Dispatch<React.SetStateAction<AudioBuffer | undefined>>,
-  recordingAudioBuffer: AudioBuffer,
+  recordingAudioBuffer: AudioBuffer | undefined,
   setPlaybackProgress: React.Dispatch<React.SetStateAction<number>>,
   soundName: SoundName
   ) => {
@@ -117,27 +117,18 @@ export const App = () => {
   };
 
   const setupAudioContextCallback = useCallback((
-    audioSource,
-    audioContext,
-    setPlaying,
-    gainNode,
-    setAudioBuffer,
-    recordingAudioBuffer,
-    setPlaybackProgress,
     soundName) => {
-      setupAudioContext(audioSource, audioContext, setPlaying, gainNode, setAudioBuffer, recordingAudioBuffer, setPlaybackProgress, soundName);
-    },
-    [],
-  );
+        setupAudioContext(audioSource, audioContext, setPlaying, gainNode, setAudioBuffer, recordingAudioBuffer, setPlaybackProgress, soundName);
+    }, [recordingAudioBuffer]);
 
   useEffect(() => {
     // AudioContext is apparently unavailable in the node / jest environment.
     // So we bail out early, to prevent render test failure.
     if (!window.AudioContext) { return; }
 
-    setupAudioContextCallback(audioSource, audioContext, setPlaying, gainNode, setAudioBuffer, recordingAudioBuffer, setPlaybackProgress, selectedSound);
+    setupAudioContextCallback(selectedSound);
   },
-    [selectedSound]
+    [selectedSound, setupAudioContextCallback]
   );
 
   useEffect(() => {

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -1,13 +1,12 @@
 import React, { ChangeEvent, useCallback, useEffect, useRef, useState } from "react";
 import Slider from "rc-slider";
 
-import { SIDE_MARGIN_PLUS_BORDER, SoundName, SOUND_WAVE_GRAPH_HEIGHT, ZOOMED_OUT_GRAPH_HEIGHT, ZOOM_BUTTONS_WIDTH, SOUND_SAMPLE_RATE } from "../types";
+import { SIDE_MARGIN_PLUS_BORDER, SoundName, SOUND_WAVE_GRAPH_HEIGHT, ZOOMED_OUT_GRAPH_HEIGHT, SOUND_SAMPLE_RATE } from "../types";
 import { SoundWave } from "./sound-wave";
 import { CarrierWave } from "./carrier-wave/carrier-wave";
 import { AppHeader } from "./application-header/application-header";
 import { SoundPicker, isPureTone, pureToneFrequencyFromSoundName } from "./sound-picker/sound-picker";
 import { useAutoWidth } from "../hooks/use-auto-width";
-import { ZoomButtons } from "./zoom-buttons/zoom-buttons";
 
 import "./app.scss";
 import "rc-slider/assets/index.css";
@@ -264,7 +263,6 @@ export const App = () => {
             handleZoomIn={handleZoomIn}
             handleZoomOut={handleZoomOut}
         />
-          {/* <ZoomButtons handleZoomIn={handleZoomIn} handleZoomOut={handleZoomOut} /> */}
           <div className="zoomed-out-graph-container chosen-sound">
             <SoundWave
               width={graphWidth}

--- a/src/components/application-header/application-header.scss
+++ b/src/components/application-header/application-header.scss
@@ -2,8 +2,8 @@
 
 .application-header-container {
     height: $applicationHeaderContainerHeight;
-    color: $controls;
-    background-color: $controlsBackground;
+    color: $controlsColor;
+    background-color: $controlsBackgroundColor;
     font-size: 24px;
     line-height: 26px;
 

--- a/src/components/application-header/application-header.test.tsx
+++ b/src/components/application-header/application-header.test.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { AppHeader } from "./application-header";
+
+describe("AppHeader", () => {
+  it("shows the elements and text", () => {
+    render(<AppHeader
+      />);
+    expect(screen.getByText("Sound Visualizer")).toBeDefined();
+    expect(screen.getByAltText("Waves Logo")).toBeDefined();
+  });
+});

--- a/src/components/carrier-wave/carrier-wave.scss
+++ b/src/components/carrier-wave/carrier-wave.scss
@@ -4,10 +4,10 @@
   margin: 10px 8px 0 8px;
   padding: 5px 0px 5px 0px;
   font-size: 80%; // 85%;
-  color: $controls;
+  color: $controlsColor;
   border: 2px solid $darkBorderColor;
   border-radius: $borderRadius;
-  background-color: $controlsBackground;
+  background-color: $controlsBackgroundColor;
 
   .carrier-picker-container {
     display: flex;
@@ -27,13 +27,13 @@
     select {
       width: 100%;
       font-size: $selectFontSize;
-      color: $controls;
+      color: $controlsColor;
       border-color: $darkBorderColor;
-      background-color: $controlsBackgroundSemiTransparent;
+      background-color: $controlsBackgroundSemiTransparentColor;
     }
 
     span.value {
-      color: $controls;
+      color: $controlsColor;
     }
   }
 

--- a/src/components/carrier-wave/carrier-wave.test.tsx
+++ b/src/components/carrier-wave/carrier-wave.test.tsx
@@ -10,7 +10,6 @@ describe("CarrierWave", () => {
         graphWidth={200}
         volume={1}
         interactive={false}
-        shouldDrawWaveCaptions={false}
       />);
     expect(screen.getByText("Radio Carrier Wave:")).toBeDefined();
   });

--- a/src/components/carrier-wave/carrier-wave.test.tsx
+++ b/src/components/carrier-wave/carrier-wave.test.tsx
@@ -12,5 +12,9 @@ describe("CarrierWave", () => {
         interactive={false}
       />);
     expect(screen.getByText("Radio Carrier Wave:")).toBeDefined();
+    expect(screen.getByText("Choose . . .")).toBeDefined();
+    expect(screen.getByText("Wavelength:")).toBeDefined();
+    expect(screen.getByText("Modulation:")).toBeDefined();
+    expect(screen.getByText("Higher than human hearing range by:")).toBeDefined();
   });
 });

--- a/src/components/carrier-wave/carrier-wave.tsx
+++ b/src/components/carrier-wave/carrier-wave.tsx
@@ -24,7 +24,6 @@ export interface ICarrierWaveProps {
   volume: number;
   onProgressUpdate?: (newProgress: number) => void;
   interactive: boolean;
-  shouldDrawWaveCaptions: boolean;
 }
 
 export const CarrierWave = (props: ICarrierWaveProps) => {

--- a/src/components/carrier-wave/carrier-wave.tsx
+++ b/src/components/carrier-wave/carrier-wave.tsx
@@ -1,8 +1,7 @@
 import React, { ChangeEvent, useEffect, useState } from "react";
-import { Modulation, ZOOM_BUTTONS_WIDTH, SOUND_WAVE_GRAPH_HEIGHT, ZOOMED_OUT_GRAPH_HEIGHT } from "../../types";
+import { Modulation, SOUND_WAVE_GRAPH_HEIGHT, ZOOMED_OUT_GRAPH_HEIGHT } from "../../types";
 import { getAMCarrierWave, getFMCarrierWave } from "../../utils/audio";
 import { SoundWave } from "../sound-wave";
-import { ZoomButtons } from "../zoom-buttons/zoom-buttons";
 
 import "./carrier-wave.scss";
 
@@ -107,7 +106,6 @@ export const CarrierWave = (props: ICarrierWaveProps) => {
             handleZoomOut={handleZoomOut}
           />
         </div>
-        {/* <ZoomButtons handleZoomIn={handleZoomIn} handleZoomOut={handleZoomOut} /> */}
         <div className="zoomed-out-graph-container chosen-carrier">
           <SoundWave
             width={graphWidth}

--- a/src/components/sound-picker/sound-picker.scss
+++ b/src/components/sound-picker/sound-picker.scss
@@ -2,31 +2,55 @@
 
 .sound-picker-container {
   height: $soundPickerContainerHeight;
-  padding: 15px 18px 5px 22px;
+  padding: 10px 12px 10px 12px;
   display: flex;
   justify-content: space-between;
+  align-items: center;
+
+  .sound-picker-mid-label {
+    padding: 0 5px;
+    font-size: 110%;
+  }
 
   .sound-picker-select-container {
     width: 100%;
-    // leave some whitespace between this and the icons
-    margin-right: 5px;
 
     .sound-picker {
-      font-size: $selectFontSize;
       width: 100%;
-      border-color: $darkBorderColor;
+      height: 28px;
+      font-size: $selectFontSize;
+      background-color: $controlsBackground;
+      color: $graphBackgroundColor;
       }
   }
 
   .icons-container {
-    width: 35px;
-    height: 32px;
-    text-align: right;
+    button {
+      width: 110px;
+      height: 30px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-direction: row;
+
+      border-radius: 10px;
+      line-height: 1;
+      background-color: $controlsBackground;
+      color: $graphBackgroundColor;
+
+      &[disabled] {
+        color: $disabledButton;
+      }
+
+      div {
+        font-size: 130%;
+      }
+    }
 
     .icon {
       height: 24px;
       width: 24px;
-      margin-left: 5px;
+      margin-top: 4px;
       cursor: pointer;
       fill: red;
 

--- a/src/components/sound-picker/sound-picker.scss
+++ b/src/components/sound-picker/sound-picker.scss
@@ -19,7 +19,7 @@
       width: 100%;
       height: 28px;
       font-size: $selectFontSize;
-      background-color: $controlsBackground;
+      background-color: $controlsBackgroundColor;
       color: $graphBackgroundColor;
       }
   }
@@ -35,11 +35,11 @@
 
       border-radius: 10px;
       line-height: 1;
-      background-color: $controlsBackground;
+      background-color: $controlsBackgroundColor;
       color: $graphBackgroundColor;
 
       &[disabled] {
-        color: $disabledButton;
+        color: $disabledButtonColor;
       }
 
       div {
@@ -65,7 +65,7 @@
       }
 
       &.disabled {
-        fill: $disabledButton;
+        fill: $disabledButtonColor;
         cursor: default;
       }
     }

--- a/src/components/sound-picker/sound-picker.scss
+++ b/src/components/sound-picker/sound-picker.scss
@@ -28,9 +28,11 @@
       width: 24px;
       margin-left: 5px;
       cursor: pointer;
+      fill: red;
 
       &.recording {
-        fill: red;
+        // fill: red;
+        fill: lawngreen;
       }
 
       &.labelling {

--- a/src/components/sound-picker/sound-picker.scss
+++ b/src/components/sound-picker/sound-picker.scss
@@ -19,7 +19,7 @@
   }
 
   .icons-container {
-    width: 74px;
+    width: 35px;
     height: 32px;
     text-align: right;
 
@@ -31,8 +31,9 @@
       fill: red;
 
       &.recording {
-        // fill: red;
-        fill: lawngreen;
+        animation-name: pulse;
+        animation-duration: 1.5s;
+        animation-iteration-count: infinite;
       }
 
       &.labelling {
@@ -44,5 +45,14 @@
         cursor: default;
       }
     }
+  }
+}
+
+@keyframes pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
   }
 }

--- a/src/components/sound-picker/sound-picker.test.tsx
+++ b/src/components/sound-picker/sound-picker.test.tsx
@@ -7,11 +7,11 @@ describe("SoundPicker", () => {
   it("shows the elements and text", () => {
     render(<SoundPicker
       selectedSound={"pick-sound" as SoundName}
-      setSelectedSound={() => {}}
+      setSelectedSound={() => { /* NO-OP */ }}
       recordingAudioBuffer={undefined}
-      setRecordingAudioBuffer={() => {}}
+      setRecordingAudioBuffer={() => { /* NO-OP */ }}
       playing={false}
-      onMyRecordingChosen={() => {}}
+      onMyRecordingChosen={() => { /* NO-OP */ }}
       />);
     expect(screen.getByText("Record")).toBeDefined();
     expect(screen.getByText("OR")).toBeDefined();

--- a/src/components/sound-picker/sound-picker.test.tsx
+++ b/src/components/sound-picker/sound-picker.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { SoundName } from "../../types";
+import { SoundPicker, isPureTone, pureToneFrequencyFromSoundName } from "./sound-picker";
+
+describe("SoundPicker", () => {
+  it("shows the elements and text", () => {
+    render(<SoundPicker
+      selectedSound={"pick-sound" as SoundName}
+      setSelectedSound={() => {}}
+      recordingAudioBuffer={undefined}
+      setRecordingAudioBuffer={() => {}}
+      playing={false}
+      onMyRecordingChosen={() => {}}
+      />);
+    expect(screen.getByText("Record")).toBeDefined();
+    expect(screen.getByText("OR")).toBeDefined();
+    expect(screen.getByText("Pick Sound")).toBeDefined();
+  });
+
+  it("tests for pure tones", () => {
+    expect(isPureTone("imaginary")).toBeFalsy();
+    expect(isPureTone("middle-c")).toBeTruthy();
+    expect(isPureTone("c2")).toBeTruthy();
+  });
+
+  it("decodes pure tone frequency numbers", () => {
+    expect(pureToneFrequencyFromSoundName("")).toEqual(0);
+    expect(pureToneFrequencyFromSoundName("middle-c")).toEqual(261.65);
+    expect(pureToneFrequencyFromSoundName("c2")).toEqual(65.41);
+  });
+});

--- a/src/components/sound-picker/sound-picker.tsx
+++ b/src/components/sound-picker/sound-picker.tsx
@@ -46,12 +46,9 @@ export const SoundPicker = (props: ISoundPickerProps) => {
     onMyRecordingChosen,
     // -- commented out, but deliberately not removed, per: PT #180792001
     // drawWaveLabels,
-    handleDrawWaveLabelChange
+    // handleDrawWaveLabelChange
   } = props;
 
-  // Set: isPureToneSelected, isReadyToRecord defaults, based on "middle-c" default selection
-  const [isPureToneSelected, setIsPureToneSelected] = useState<boolean>(true);
-  const [isReadyToRecord, setIsReadyToRecord] = useState<boolean>(true);
   const [isRecording, setIsRecording] = useState<boolean>(false);
   const [hasRecording, setHasRecording] = useState<boolean>(false);
 
@@ -100,10 +97,7 @@ console.log("onstop");
       const blob = new Blob(audioRecordingChunks, { "type" : recorder.mimeType });
       const audioURL = window.URL.createObjectURL(blob);
       const arrayBuffer = await (await fetch(audioURL)).arrayBuffer();
-      // let audioBuffer = await (new AudioContext()).decodeAudioData(arrayBuffer);
-      // audioBuffer2.current = await (new AudioContext()).decodeAudioData(arrayBuffer);
       let recordingAudioBuffer = await (new AudioContext()).decodeAudioData(arrayBuffer);
-      // setRecordingAudioBuffer(recordingAudioBuffer);
 
       // let channelData = audioBuffer.getChannelData(0);
       // let channelData = audioBuffer2.current.getChannelData(0);
@@ -129,44 +123,28 @@ console.log("onstop");
       // sounds of interest.
       if (firstSoundIndex !== -1) {
         const extraSamplesOffset =
-          // audioBuffer.sampleRate * 0.2; // 200 milliseconds of samples
-          // (audioBuffer2 && audioBuffer2.current && audioBuffer2.current.sampleRate)
-          //   ? (audioBuffer2.current.sampleRate * 0.2) // 200 milliseconds of samples
-          //   : 0;
           recordingAudioBuffer.sampleRate * 0.2; // 200 milliseconds of samples
 
         const adjustedSoundIndex = Math.max(0, (firstSoundIndex - extraSamplesOffset));
         channelData = channelData.slice(firstSoundIndex);
 
-        // audioBuffer = new AudioBuffer({
-        //   length: audioBuffer.length - adjustedSoundIndex,
-        //   sampleRate: audioBuffer.sampleRate
-        // });
-        // audioBuffer2.current = new AudioBuffer({
-        //   length: audioBuffer2.current.length - adjustedSoundIndex,
-        //   sampleRate: audioBuffer2.current.sampleRate
-        // });
         recordingAudioBuffer = new AudioBuffer({
           length: recordingAudioBuffer.length - adjustedSoundIndex,
           sampleRate: recordingAudioBuffer.sampleRate
         });
         setRecordingAudioBuffer(recordingAudioBuffer);
 
-        // audioBuffer.copyToChannel(channelData, 0);
-        // audioBuffer2.current.copyToChannel(channelData, 0);
         recordingAudioBuffer.copyToChannel(channelData, 0);
       }
 
       // When a recording is completed, we choose it automatically (PT #180792001).
-      // onMyRecordingChosen(audioBuffer);
-      // onMyRecordingChosen(audioBuffer2.current);
       onMyRecordingChosen(recordingAudioBuffer);
 
       audioRecordingChunks = [];
     };
 
     mediaRecorderRef.current = recorder;
-    setIsReadyToRecord(true);
+    // setIsReadyToRecord(true);
 console.log("is ready to record...");
   };
 
@@ -225,15 +203,11 @@ console.log(mediaRecorderRef.current);
 
   const onSoundPickerChange = (event: ChangeEvent<HTMLSelectElement>) => {
     const soundName = event.currentTarget.value as SoundName;
-    setIsPureToneSelected(isPureTone(soundName));
     const isUserRecordingSelected = (soundName === "record-my-own");
     const hasMediaRecorder = !!(mediaRecorderRef.current);
 console.log("onSoundPickerChange", {mediaRecorderRef}, {hasMediaRecorder});
-// setIsReadyToRecord(hasMediaRecorder && isUserRecordingSelected);
     if (isUserRecordingSelected && !hasMediaRecorder) {
         accessRecordingStream();
-        // onMyRecordingChosen(audioBuffer);
-        // onMyRecordingChosen(audioBuffer2.current);
         onMyRecordingChosen(recordingAudioBuffer);
       }
 

--- a/src/components/sound-picker/sound-picker.tsx
+++ b/src/components/sound-picker/sound-picker.tsx
@@ -2,13 +2,15 @@ import React, { ChangeEvent, useRef, useState } from "react";
 
 import { SoundName } from "../../types";
 import MicIcon from "../../assets/icons/mic_black_48dp.svg";
-import LabelsIcon from "../../assets/icons/sell_black_48dp.svg";
+  // -- commented out, but deliberately not removed, per: PT #180792001
+  // import LabelsIcon from "../../assets/icons/sell_black_48dp.svg";
 
 import "./sound-picker.scss";
 
 export interface ISoundPickerProps {
   selectedSound: SoundName;
   drawWaveLabels: boolean;
+  playing: boolean;
   handleSoundChange?: (event: ChangeEvent<HTMLSelectElement>) => void;
   onRecordingCompleted?: (audioBuffer: AudioBuffer) => void;
   handleDrawWaveLabelChange?: () => void;
@@ -31,12 +33,19 @@ export const pureToneFrequencyFromSoundName = (soundName: string) => {
 };
 
 export const SoundPicker = (props: ISoundPickerProps) => {
-  const { selectedSound, handleSoundChange, onRecordingCompleted, drawWaveLabels, handleDrawWaveLabelChange } = props;
+  const {
+    selectedSound,
+    playing,
+    handleSoundChange,
+    onRecordingCompleted,
+    // -- commented out, but deliberately not removed, per: PT #180792001
+    // drawWaveLabels,
+    handleDrawWaveLabelChange
+  } = props;
 
   // Set: isPureToneSelected, isReadyToRecord defaults, based on "middle-c" default selection
   const [isPureToneSelected, setIsPureToneSelected] = useState<boolean>(true);
-  const [isReadyToRecord, setIsReadyToRecord] = useState<boolean>(false);
-
+  const [isReadyToRecord, setIsReadyToRecord] = useState<boolean>(true);
   const [isRecording, setIsRecording] = useState<boolean>(false);
 
   const recordingTimerRef = useRef<number>();
@@ -125,21 +134,31 @@ export const SoundPicker = (props: ISoundPickerProps) => {
   };
 
   const onMicIconClicked = () => {
+console.log({mediaRecorderRef})
     const maximumRecordingLengthInMilliseconds = 1000 * 5;
 
-    // Ignore this event, if it happens when "(record my own) is NOT selected"
-    if (!isReadyToRecord) { return; }
-
-    if (mediaRecorderRef.current?.state === "inactive") {
-
-      // Use a one-shot timer, to ensure recording does not exceed the maximum length
-      recordingTimerRef.current = setTimeout(onTimedOutRecording, maximumRecordingLengthInMilliseconds);
-
-      mediaRecorderRef.current?.start();
-      setIsRecording(true);
-    } else {
+    if (isRecording) {
       doFinishedRecording();
+      return;
     }
+
+    const isRecordingConfirmed = window.confirm("Press OK to begin recording for 5 seconds.");
+    if (!isRecordingConfirmed) { return; }
+
+    setIsRecording(true);
+    // Use a one-shot timer, to ensure recording does not exceed the maximum length
+    recordingTimerRef.current =
+      setTimeout(onTimedOutRecording, maximumRecordingLengthInMilliseconds);
+
+
+    // if (mediaRecorderRef.current?.state === "inactive") {
+    //   // Use a one-shot timer, to ensure recording does not exceed the maximum length
+    //   recordingTimerRef.current = setTimeout(onTimedOutRecording, maximumRecordingLengthInMilliseconds);
+    //   mediaRecorderRef.current?.start();
+    //   setIsRecording(true);
+    // } else {
+    //   doFinishedRecording();
+    // }
   };
 
   // -- commented out, but deliberately not removed, per: PT #180792001
@@ -178,12 +197,12 @@ export const SoundPicker = (props: ISoundPickerProps) => {
           <option value="cosmic-arp">Cosmic Arp</option>
           <option value="hard-base">Hard Base</option>
           <option value="scratch-sample">Scratch Sample</option>
-          <option value="record-my-own">(record my own . . .)</option>
+          <option value="record-my-own">(My Recording)</option>
         </select>
       </div>
       <div className="icons-container">
         <MicIcon className={
-          `icon button ${isReadyToRecord ? "" : "disabled"} ${isRecording ? "recording" : ""}`}
+          `icon button ${playing ? "disabled" : ""} ${isRecording ? "recording" : ""}`}
           onClick={onMicIconClicked} />
         {/* // -- commented out, but deliberately not removed, per: PT #180792001 */}
         {/* <LabelsIcon className={

--- a/src/components/sound-picker/sound-picker.tsx
+++ b/src/components/sound-picker/sound-picker.tsx
@@ -10,7 +10,7 @@ import "./sound-picker.scss";
 export interface ISoundPickerProps {
   selectedSound: SoundName;
   setSelectedSound: (soundName: SoundName) => void;
-  recordingAudioBuffer: AudioBuffer;
+  recordingAudioBuffer: AudioBuffer | undefined;
   setRecordingAudioBuffer: (audioBuffer: AudioBuffer) => void;
   drawWaveLabels: boolean;
   playing: boolean;
@@ -179,7 +179,7 @@ export const SoundPicker = (props: ISoundPickerProps) => {
     const soundName = event.currentTarget.value as SoundName;
     const isUserRecordingSelected = (soundName === "record-my-own");
     const hasMediaRecorder = !!(mediaRecorderRef.current);
-    if (isUserRecordingSelected && !hasMediaRecorder) {
+    if (isUserRecordingSelected && !hasMediaRecorder && recordingAudioBuffer) {
         accessRecordingStream();
         onMyRecordingChosen(recordingAudioBuffer);
       }

--- a/src/components/sound-picker/sound-picker.tsx
+++ b/src/components/sound-picker/sound-picker.tsx
@@ -142,11 +142,12 @@ export const SoundPicker = (props: ISoundPickerProps) => {
     }
   };
 
-  const onLabelIconClicked = () => {
-    // Don't allow state change when non-pure tone sound selected
-    if (!isPureToneSelected) { return; }
-    handleDrawWaveLabelChange?.();
-  };
+  // -- commented out, but deliberately not removed, per: PT #180792001
+  // const onLabelIconClicked = () => {
+  //   // Don't allow state change when non-pure tone sound selected
+  //   if (!isPureToneSelected) { return; }
+  //   handleDrawWaveLabelChange?.();
+  // };
 
   const onSoundPickerChange = (event: ChangeEvent<HTMLSelectElement>) => {
     const soundName = event.currentTarget.value as SoundName;
@@ -184,10 +185,11 @@ export const SoundPicker = (props: ISoundPickerProps) => {
         <MicIcon className={
           `icon button ${isReadyToRecord ? "" : "disabled"} ${isRecording ? "recording" : ""}`}
           onClick={onMicIconClicked} />
-        <LabelsIcon className={
+        {/* // -- commented out, but deliberately not removed, per: PT #180792001 */}
+        {/* <LabelsIcon className={
             `icon button ${isPureToneSelected ? "" : "disabled"} ${drawWaveLabels ? "labelling" : ""}`
           }
-          onClick={onLabelIconClicked} />
+          onClick={onLabelIconClicked} /> */}
       </div>
     </div>
   );

--- a/src/components/sound-picker/sound-picker.tsx
+++ b/src/components/sound-picker/sound-picker.tsx
@@ -2,8 +2,6 @@ import React, { ChangeEvent, useRef, useState } from "react";
 
 import { SoundName } from "../../types";
 import MicIcon from "../../assets/icons/mic_black_48dp.svg";
-  // -- commented out, but deliberately not removed, per: PT #180792001
-  // import LabelsIcon from "../../assets/icons/sell_black_48dp.svg";
 
 import "./sound-picker.scss";
 
@@ -12,7 +10,6 @@ export interface ISoundPickerProps {
   setSelectedSound: (soundName: SoundName) => void;
   recordingAudioBuffer: AudioBuffer | undefined;
   setRecordingAudioBuffer: (audioBuffer: AudioBuffer) => void;
-  drawWaveLabels: boolean;
   playing: boolean;
   onMyRecordingChosen: (audioBuffer: AudioBuffer) => void;
   handleDrawWaveLabelChange?: () => void;
@@ -42,9 +39,6 @@ export const SoundPicker = (props: ISoundPickerProps) => {
     setRecordingAudioBuffer,
     playing,
     onMyRecordingChosen,
-    // -- commented out, but deliberately not removed, per: PT #180792001
-    // drawWaveLabels,
-    // handleDrawWaveLabelChange
   } = props;
 
   const [isRecording, setIsRecording] = useState<boolean>(false);
@@ -161,13 +155,6 @@ export const SoundPicker = (props: ISoundPickerProps) => {
       setTimeout(onTimedOutRecording, maximumRecordingLengthInMilliseconds);
   };
 
-  // -- commented out, but deliberately not removed, per: PT #180792001
-  // const onLabelIconClicked = () => {
-  //   // Don't allow state change when non-pure tone sound selected
-  //   if (!isPureToneSelected) { return; }
-  //   handleDrawWaveLabelChange?.();
-  // };
-
 
   const onSoundPickerChange = (event: ChangeEvent<HTMLSelectElement>) => {
     const soundName = event.currentTarget.value as SoundName;
@@ -181,9 +168,9 @@ export const SoundPicker = (props: ISoundPickerProps) => {
     }
 
     if (isUserRecordingSelected && !hasMediaRecorder && recordingAudioBuffer) {
-        accessRecordingStream();
-        onMyRecordingChosen(recordingAudioBuffer);
-      }
+      accessRecordingStream();
+      onMyRecordingChosen(recordingAudioBuffer);
+    }
     setSelectedSound(soundName);
   };
 
@@ -200,11 +187,6 @@ export const SoundPicker = (props: ISoundPickerProps) => {
           </div>
           <div>Record</div>
         </button>
-        {/* // -- commented out, but deliberately not removed, per: PT #180792001 */}
-        {/* <LabelsIcon className={
-            `icon button ${isPureToneSelected ? "" : "disabled"} ${drawWaveLabels ? "labelling" : ""}`
-          }
-          onClick={onLabelIconClicked} /> */}
       </div>
 
       <div className="sound-picker-mid-label">OR</div>

--- a/src/components/sound-picker/sound-picker.tsx
+++ b/src/components/sound-picker/sound-picker.tsx
@@ -47,6 +47,7 @@ export const SoundPicker = (props: ISoundPickerProps) => {
   const [isPureToneSelected, setIsPureToneSelected] = useState<boolean>(true);
   const [isReadyToRecord, setIsReadyToRecord] = useState<boolean>(true);
   const [isRecording, setIsRecording] = useState<boolean>(false);
+  const [hasRecording, setHasRecording] = useState<boolean>(false);
 
   const recordingTimerRef = useRef<number>();
   const mediaRecorderRef = useRef<MediaRecorder>();
@@ -127,6 +128,8 @@ export const SoundPicker = (props: ISoundPickerProps) => {
 
     mediaRecorderRef.current?.stop();
     setIsRecording(false);
+console.log("setting hasRecording to true")
+    setHasRecording(true);
   };
 
   const onTimedOutRecording = () => {
@@ -197,7 +200,7 @@ console.log({mediaRecorderRef})
           <option value="cosmic-arp">Cosmic Arp</option>
           <option value="hard-base">Hard Base</option>
           <option value="scratch-sample">Scratch Sample</option>
-          <option value="record-my-own">(My Recording)</option>
+          <option value="record-my-own" disabled={!hasRecording}>(My Recording)</option>
         </select>
       </div>
       <div className="icons-container">

--- a/src/components/sound-wave.scss
+++ b/src/components/sound-wave.scss
@@ -14,7 +14,7 @@
 
   &.zoomed-in-view canvas {
     background-color: $graphBackgroundColor;
-    border-color: $waveGraphMarker;
+    border-color: $waveGraphMarkerColor;
   }
 
   .frequency {

--- a/src/components/sound-wave.tsx
+++ b/src/components/sound-wave.tsx
@@ -16,9 +16,6 @@ export const SoundWave = (props: ISoundWaveProps) => {
     audioBuffer,
     zoom,
     zoomedInView,
-    // -- commented out, but deliberately not removed, per: PT #180792001
-    // shouldDrawWaveCaptions,
-    // pureToneFrequency,
     handleZoomIn,
     handleZoomOut
   } = props;
@@ -50,11 +47,6 @@ export const SoundWave = (props: ISoundWaveProps) => {
 
   return (
     <div className={cssClasses}>
-      {
-        //  -- commented out, but deliberately not removed, per: PT #180792001
-        // shouldDrawWaveCaptions && pureToneFrequency &&
-        // <div className="frequency">Frequency: {pureToneFrequency} Hz</div>
-      }
       <canvas
         ref={canvasRef}
         onPointerDown={interactive ? handlePointerDown : undefined}

--- a/src/components/sound-wave.tsx
+++ b/src/components/sound-wave.tsx
@@ -11,7 +11,17 @@ import "./sound-wave.scss";
 const MAX_GRAPH_POINTS = 20000;
 
 export const SoundWave = (props: ISoundWaveProps) => {
-  const { interactive, audioBuffer, zoom, zoomedInView, shouldDrawWaveCaptions, pureToneFrequency, handleZoomIn, handleZoomOut } = props;
+  const {
+    interactive,
+    audioBuffer,
+    zoom,
+    zoomedInView,
+    // -- commented out, but deliberately not removed, per: PT #180792001
+    // shouldDrawWaveCaptions,
+    // pureToneFrequency,
+    handleZoomIn,
+    handleZoomOut
+  } = props;
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [data, setData] = useState<Float32Array>(new Float32Array(0));
 

--- a/src/components/sound-wave.tsx
+++ b/src/components/sound-wave.tsx
@@ -39,8 +39,9 @@ export const SoundWave = (props: ISoundWaveProps) => {
   return (
     <div className={cssClasses}>
       {
-        shouldDrawWaveCaptions && pureToneFrequency &&
-        <div className="frequency">Frequency: {pureToneFrequency} Hz</div>
+        //  -- commented out, but deliberately not removed, per: PT #180792001
+        // shouldDrawWaveCaptions && pureToneFrequency &&
+        // <div className="frequency">Frequency: {pureToneFrequency} Hz</div>
       }
       <canvas
         ref={canvasRef}

--- a/src/components/vars.scss
+++ b/src/components/vars.scss
@@ -1,4 +1,3 @@
-$applicationBackground: white;
 $applicationHeaderContainerHeight: 50px;
 $soundPickerContainerHeight: 30px;
 $soundWaveContainerHeight: 270px;
@@ -9,17 +8,17 @@ $borderRadius: 10px;
 $selectFontSize: 18px;
 $smallLabelFontSize: 70%;
 
+$applicationBackgroundColor: white;
 $darkGray: #494949;
 $borderColor: #e0e0e0;
 $darkBorderColor: #d0d0ff;
-$controls: white;
-$controlsBackground: #024059;
-$controlsAlternateBackground: #3377BD;
-$controlsBackgroundSemiTransparent: #ffffff20;
-$zoomControlsContainerBackground: #ffffffb0;
-$zoomControlsContainerBorder: #3377BDe0;
-$disabledButton: #aaa;
-$waveGraphMarker: #ea6d2f;
-
+$controlsColor: white;
+$controlsBackgroundColor: #024059;
+$controlsAlternateBackgroundColor: #3377BD;
+$controlsBackgroundSemiTransparentColor: #ffffff20;
+$zoomControlsContainerBackgroundColor: #ffffffb0;
+$zoomControlsContainerBorderColor: #3377BDe0;
+$disabledButtonColor: #aaa;
+$waveGraphMarkerColor: #ea6d2f;
 $graphBackgroundColor: white;
 $zoomedOutGraphBackgroundColor: #F0F0F0;

--- a/src/components/zoom-buttons/zoom-buttons.scss
+++ b/src/components/zoom-buttons/zoom-buttons.scss
@@ -12,18 +12,18 @@
   align-items: center;
   justify-content: space-around;
   padding: 2px 0px;
-  background-color: $zoomControlsContainerBackground;
-  border: 1px solid $zoomControlsContainerBorder;
+  background-color: $zoomControlsContainerBackgroundColor;
+  border: 1px solid $zoomControlsContainerBorderColor;
 }
 
 .zoom-button {
   height: 24px;
   width: 24px;
   cursor: pointer;
-  background-color: $controlsAlternateBackground;
+  background-color: $controlsAlternateBackgroundColor;
   border-radius: 6px;
   svg {
-    fill: $controls;
+    fill: $controlsColor;
     height: 24px;
     width: 24px;
   }

--- a/src/components/zoom-buttons/zoom-buttons.test.tsx
+++ b/src/components/zoom-buttons/zoom-buttons.test.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ZoomButtons } from "./zoom-buttons";
+
+describe("ZoomButtons", () => {
+  it("shows the elements and text", () => {
+    render(<ZoomButtons
+      />);
+    expect(screen.getByTestId("zoom-in-button")).toBeDefined();
+    expect(screen.getByTestId("zoom-out-button")).toBeDefined();
+  });
+});

--- a/src/components/zoom-buttons/zoom-buttons.tsx
+++ b/src/components/zoom-buttons/zoom-buttons.tsx
@@ -13,13 +13,21 @@ export const ZoomButtons = (props: IZoomButtonsProps) => {
       className="zoom-buttons-container"
     >
       <div className="zoom-button-container">
-        <div className="zoom-button" onClick={handleZoomIn} >
+        <div
+          data-testid="zoom-in-button"
+          className="zoom-button"
+          onClick={handleZoomIn}
+          >
           <PlusIcon />
         </div>
       </div>
 
       <div className="zoom-button-container">
-        <div className="zoom-button" onClick={handleZoomOut} >
+        <div
+          data-testid="zoom-out-button"
+          className="zoom-button"
+          onClick={handleZoomOut}
+          >
           <MinusIcon />
         </div>
       </div>

--- a/src/components/zoom-buttons/zoom-buttons.tsx
+++ b/src/components/zoom-buttons/zoom-buttons.tsx
@@ -13,20 +13,14 @@ export const ZoomButtons = (props: IZoomButtonsProps) => {
       className="zoom-buttons-container"
     >
       <div className="zoom-button-container">
-        <div
-          className="zoom-button"
-          onClick={handleZoomOut}
-        >
-          <MinusIcon />
+        <div className="zoom-button" onClick={handleZoomIn} >
+          <PlusIcon />
         </div>
       </div>
 
       <div className="zoom-button-container">
-        <div
-          className="zoom-button"
-          onClick={handleZoomIn}
-        >
-          <PlusIcon />
+        <div className="zoom-button" onClick={handleZoomOut} >
+          <MinusIcon />
         </div>
       </div>
     </div>

--- a/src/hooks/use-sound-wave-rendering.ts
+++ b/src/hooks/use-sound-wave-rendering.ts
@@ -99,132 +99,9 @@ const drawZoomAreaMarker = (props: IDrawHelperProps) => {
   ctx.fillRect(x * xScale + 0.5 * markerWidth, 0, 1, height); // line
 };
 
-        // -- commented out, but deliberately not removed, per: PT #180792001
-// Used only in the zoomed in view.
-// const drawAmplitudeMarker = (props: IDrawHelperProps) => {
-//   const { ctx, width, height, zoom } = props;
-
-//   const markerPadding = Math.round(2000 / zoom); // X samples point away from the center
-//   const kSampleDiff = 5;
-//   const baseY = height * 0.5;
-
-//   const pointsCount = getPointsCount(props);
-//   const currentDataPointIdx = getCurrentSampleIdx(props);
-
-//   const startIdx = currentDataPointIdx + markerPadding;
-
-//   let amplitudeX = null;
-//   let amplitudeY = null;
-//   for (let i = startIdx; i < currentDataPointIdx + pointsCount * 0.5; i++) {
-//     const y1 = getCurrentAmplitudeY(props, i - kSampleDiff);
-//     const y2 = getCurrentAmplitudeY(props, i);
-//     const y3 = getCurrentAmplitudeY(props, i + kSampleDiff);
-//     // Find the local min (note that the Y axis is upside down -> 0 is at the top of the canvas).
-//     if ((y1 > y2) && (y2 < y3)) {
-//       amplitudeX = i;
-//       amplitudeY = y2;
-//       break;
-//     }
-//   }
-
-//   if (amplitudeX !== null && amplitudeY !== null) {
-//     const kLineWidth = 3;
-//     const xScale = width / pointsCount;
-//     const minPointIdx = currentDataPointIdx - 0.5 * pointsCount; // currentDataPointIdx is always in the middle
-//     const xScaled = (amplitudeX - minPointIdx) * xScale - 0.5 * kLineWidth;
-//     const amplitudeLineHeight = amplitudeY - baseY;
-//     // Vertical line
-//     ctx.fillStyle = "#892be2";
-//     ctx.fillRect(xScaled, baseY, kLineWidth, amplitudeLineHeight);
-//     // I-beam
-//     const kIBeamWidth = 12;
-//     ctx.fillRect(xScaled - 0.5 * kIBeamWidth + 0.5 * kLineWidth, amplitudeY - kLineWidth, kIBeamWidth, kLineWidth);
-//     ctx.fillRect(xScaled - 0.5 * kIBeamWidth + 0.5 * kLineWidth, baseY - 0.5 * kLineWidth, kIBeamWidth, kLineWidth);
-//     // Draw (semi-opaque) background for the text
-//     const kTextTopPadding = 6;
-//     const kTextFontSize = 14;
-//     const kBoxWidth = 75;
-//     const kBoxHeight = kTextFontSize * 1.33;
-//     const textY = Math.max(18, amplitudeY - kTextTopPadding);
-//     ctx.fillStyle = "#ffffffb0";
-//     ctx.fillRect(xScaled + kIBeamWidth * 0.6, textY - kTextFontSize, kBoxWidth, kBoxHeight);
-//     // Label
-//     ctx.fillStyle = "#892be2";
-//     ctx.textAlign = "left";
-//     ctx.font = `${kTextFontSize}px Comfortaa, cursive`;
-//     ctx.fillText("Amplitude", xScaled + kIBeamWidth * 0.6, textY);
-//   }
-// };
-
-        // -- commented out, but deliberately not removed, per: PT #180792001
-// const drawWaveLengthMarker = (props: IDrawHelperProps) => {
-//   const { ctx, width, height, zoom, data, pureToneFrequency } = props;
-
-//   const kSampleDiff = 1;
-//   const baseY = height * 0.5;
-//   const pointsCount = getPointsCount(props);
-//   // X samples point away from the center
-//   const markerPadding = Math.min(pointsCount * 0.25, Math.round(20000 / zoom));
-
-//   const currentDataPointIdx = getCurrentSampleIdx(props);
-
-//   const startIdx = currentDataPointIdx + markerPadding;
-
-//   let waveX1 = null; // X coord of the first sign change
-//   let waveX2 = null; // X coord of the second sign change
-//   let waveX3 = null; // X coord of the third sign change
-//   for (let i = startIdx; i < currentDataPointIdx + pointsCount * 0.5; i++) {
-//     const y1 = data[i - kSampleDiff];
-//     const y2 = data[i + kSampleDiff];
-//     if (y1 !== undefined && y2 !== undefined && Math.sign(y1) !== Math.sign(y2)) {
-//       if (waveX1 === null) {
-//         waveX1 = i;
-//         i += kSampleDiff * 2;
-//       } else if (waveX2 === null) {
-//         waveX2 = i;
-//         i += kSampleDiff * 2;
-//       } else {
-//         waveX3 = i;
-//         break;
-//       }
-//     }
-//   }
-
-//   if (waveX1 !== null && waveX3 !== null) {
-//     const kLineWidth = 3;
-//     const xScale = width / pointsCount;
-//     const minPointIdx = currentDataPointIdx - 0.5 * pointsCount; // currentDataPointIdx is always in the middle
-//     const x1Scaled = (waveX1 - minPointIdx) * xScale;
-//     const x3Scaled = (waveX3 - minPointIdx) * xScale;
-
-//     // Horizontal line
-//     ctx.fillStyle = "#892be2";
-//     ctx.fillRect(x1Scaled, baseY - 0.5 * kLineWidth, (x3Scaled - x1Scaled), kLineWidth);
-
-//     // I-beam
-//     const kIBeamWidth = 12;
-//     ctx.fillRect(x1Scaled - kLineWidth, baseY - kIBeamWidth * 0.5, kLineWidth, kIBeamWidth);
-//     ctx.fillRect(x3Scaled, baseY - kIBeamWidth * 0.5, kLineWidth, kIBeamWidth);
-
-//     // Draw (semi-opaque) background for the text
-//     const kTextFontSize = 14;
-//     const kTextTopPadding = 40;
-//     const kBoxWidth = 150;
-//     const kBoxHeight = kTextFontSize * 1.33;
-//     ctx.fillStyle = "#ffffffb0";
-//     ctx.fillRect((x1Scaled + x3Scaled) * 0.5 - 0.5 * kBoxWidth, baseY + 0.65 * kTextTopPadding, kBoxWidth, kBoxHeight);
-
-//     // Label
-//     ctx.fillStyle = "#892be2";
-//     ctx.textAlign = "center";
-//     ctx.font = `${kTextFontSize} Comfortaa, cursive`;
-//     const wavelengthInMs = 1 / (pureToneFrequency || 1) * 1000;
-//     ctx.fillText(`Wave length: ${wavelengthInMs.toFixed(2)}ms`, (x1Scaled + x3Scaled) * 0.5, baseY + kTextTopPadding);
-//   }
-// };
 
 export const useSoundWaveRendering = (canvasRef: RefObject<HTMLCanvasElement>, data: Float32Array, props: ISoundWaveProps) => {
-  const { width, height, audioBuffer, volume, playbackProgress, zoom, zoomedInView, shouldDrawProgressMarker, shouldDrawWaveCaptions: shouldDrawAmplitudeWavelengthCaptions, pureToneFrequency } = props;
+  const { width, height, audioBuffer, volume, playbackProgress, zoom, zoomedInView, shouldDrawProgressMarker, pureToneFrequency } = props;
 
   useEffect(() => {
     if (!canvasRef.current) {
@@ -249,13 +126,8 @@ export const useSoundWaveRendering = (canvasRef: RefObject<HTMLCanvasElement>, d
       if (shouldDrawProgressMarker) {
         drawProgressMarker(drawHelperProps);
       }
-      if (shouldDrawAmplitudeWavelengthCaptions) {
-        // commented out, but deliberately not removed, per: PT #180792001
-        // drawAmplitudeMarker(drawHelperProps);
-        // drawWaveLengthMarker(drawHelperProps);
-      }
     } else {
       drawZoomAreaMarker(drawHelperProps);
     }
-  }, [canvasRef, width, height, audioBuffer, data, volume, playbackProgress, zoom, zoomedInView, pureToneFrequency, shouldDrawAmplitudeWavelengthCaptions, shouldDrawProgressMarker]);
+  }, [canvasRef, width, height, audioBuffer, data, volume, playbackProgress, zoom, zoomedInView, pureToneFrequency, shouldDrawProgressMarker]);
 };

--- a/src/hooks/use-sound-wave-rendering.ts
+++ b/src/hooks/use-sound-wave-rendering.ts
@@ -194,13 +194,16 @@ const drawWaveLengthMarker = (props: IDrawHelperProps) => {
     const minPointIdx = currentDataPointIdx - 0.5 * pointsCount; // currentDataPointIdx is always in the middle
     const x1Scaled = (waveX1 - minPointIdx) * xScale;
     const x3Scaled = (waveX3 - minPointIdx) * xScale;
+
     // Horizontal line
     ctx.fillStyle = "#892be2";
     ctx.fillRect(x1Scaled, baseY - 0.5 * kLineWidth, (x3Scaled - x1Scaled), kLineWidth);
+
     // I-beam
     const kIBeamWidth = 12;
     ctx.fillRect(x1Scaled - kLineWidth, baseY - kIBeamWidth * 0.5, kLineWidth, kIBeamWidth);
     ctx.fillRect(x3Scaled, baseY - kIBeamWidth * 0.5, kLineWidth, kIBeamWidth);
+
     // Draw (semi-opaque) background for the text
     const kTextFontSize = 14;
     const kTextTopPadding = 40;
@@ -208,6 +211,7 @@ const drawWaveLengthMarker = (props: IDrawHelperProps) => {
     const kBoxHeight = kTextFontSize * 1.33;
     ctx.fillStyle = "#ffffffb0";
     ctx.fillRect((x1Scaled + x3Scaled) * 0.5 - 0.5 * kBoxWidth, baseY + 0.65 * kTextTopPadding, kBoxWidth, kBoxHeight);
+
     // Label
     ctx.fillStyle = "#892be2";
     ctx.textAlign = "center";
@@ -244,8 +248,9 @@ export const useSoundWaveRendering = (canvasRef: RefObject<HTMLCanvasElement>, d
         drawProgressMarker(drawHelperProps);
       }
       if (shouldDrawAmplitudeWavelengthCaptions) {
-        drawAmplitudeMarker(drawHelperProps);
-        drawWaveLengthMarker(drawHelperProps);
+        // commented out, but deliberately not removed, per: PT #180792001
+        // drawAmplitudeMarker(drawHelperProps);
+        // drawWaveLengthMarker(drawHelperProps);
       }
     } else {
       drawZoomAreaMarker(drawHelperProps);

--- a/src/hooks/use-sound-wave-rendering.ts
+++ b/src/hooks/use-sound-wave-rendering.ts
@@ -99,127 +99,129 @@ const drawZoomAreaMarker = (props: IDrawHelperProps) => {
   ctx.fillRect(x * xScale + 0.5 * markerWidth, 0, 1, height); // line
 };
 
+        // -- commented out, but deliberately not removed, per: PT #180792001
 // Used only in the zoomed in view.
-const drawAmplitudeMarker = (props: IDrawHelperProps) => {
-  const { ctx, width, height, zoom } = props;
+// const drawAmplitudeMarker = (props: IDrawHelperProps) => {
+//   const { ctx, width, height, zoom } = props;
 
-  const markerPadding = Math.round(2000 / zoom); // X samples point away from the center
-  const kSampleDiff = 5;
-  const baseY = height * 0.5;
+//   const markerPadding = Math.round(2000 / zoom); // X samples point away from the center
+//   const kSampleDiff = 5;
+//   const baseY = height * 0.5;
 
-  const pointsCount = getPointsCount(props);
-  const currentDataPointIdx = getCurrentSampleIdx(props);
+//   const pointsCount = getPointsCount(props);
+//   const currentDataPointIdx = getCurrentSampleIdx(props);
 
-  const startIdx = currentDataPointIdx + markerPadding;
+//   const startIdx = currentDataPointIdx + markerPadding;
 
-  let amplitudeX = null;
-  let amplitudeY = null;
-  for (let i = startIdx; i < currentDataPointIdx + pointsCount * 0.5; i++) {
-    const y1 = getCurrentAmplitudeY(props, i - kSampleDiff);
-    const y2 = getCurrentAmplitudeY(props, i);
-    const y3 = getCurrentAmplitudeY(props, i + kSampleDiff);
-    // Find the local min (note that the Y axis is upside down -> 0 is at the top of the canvas).
-    if ((y1 > y2) && (y2 < y3)) {
-      amplitudeX = i;
-      amplitudeY = y2;
-      break;
-    }
-  }
+//   let amplitudeX = null;
+//   let amplitudeY = null;
+//   for (let i = startIdx; i < currentDataPointIdx + pointsCount * 0.5; i++) {
+//     const y1 = getCurrentAmplitudeY(props, i - kSampleDiff);
+//     const y2 = getCurrentAmplitudeY(props, i);
+//     const y3 = getCurrentAmplitudeY(props, i + kSampleDiff);
+//     // Find the local min (note that the Y axis is upside down -> 0 is at the top of the canvas).
+//     if ((y1 > y2) && (y2 < y3)) {
+//       amplitudeX = i;
+//       amplitudeY = y2;
+//       break;
+//     }
+//   }
 
-  if (amplitudeX !== null && amplitudeY !== null) {
-    const kLineWidth = 3;
-    const xScale = width / pointsCount;
-    const minPointIdx = currentDataPointIdx - 0.5 * pointsCount; // currentDataPointIdx is always in the middle
-    const xScaled = (amplitudeX - minPointIdx) * xScale - 0.5 * kLineWidth;
-    const amplitudeLineHeight = amplitudeY - baseY;
-    // Vertical line
-    ctx.fillStyle = "#892be2";
-    ctx.fillRect(xScaled, baseY, kLineWidth, amplitudeLineHeight);
-    // I-beam
-    const kIBeamWidth = 12;
-    ctx.fillRect(xScaled - 0.5 * kIBeamWidth + 0.5 * kLineWidth, amplitudeY - kLineWidth, kIBeamWidth, kLineWidth);
-    ctx.fillRect(xScaled - 0.5 * kIBeamWidth + 0.5 * kLineWidth, baseY - 0.5 * kLineWidth, kIBeamWidth, kLineWidth);
-    // Draw (semi-opaque) background for the text
-    const kTextTopPadding = 6;
-    const kTextFontSize = 14;
-    const kBoxWidth = 75;
-    const kBoxHeight = kTextFontSize * 1.33;
-    const textY = Math.max(18, amplitudeY - kTextTopPadding);
-    ctx.fillStyle = "#ffffffb0";
-    ctx.fillRect(xScaled + kIBeamWidth * 0.6, textY - kTextFontSize, kBoxWidth, kBoxHeight);
-    // Label
-    ctx.fillStyle = "#892be2";
-    ctx.textAlign = "left";
-    ctx.font = `${kTextFontSize}px Comfortaa, cursive`;
-    ctx.fillText("Amplitude", xScaled + kIBeamWidth * 0.6, textY);
-  }
-};
+//   if (amplitudeX !== null && amplitudeY !== null) {
+//     const kLineWidth = 3;
+//     const xScale = width / pointsCount;
+//     const minPointIdx = currentDataPointIdx - 0.5 * pointsCount; // currentDataPointIdx is always in the middle
+//     const xScaled = (amplitudeX - minPointIdx) * xScale - 0.5 * kLineWidth;
+//     const amplitudeLineHeight = amplitudeY - baseY;
+//     // Vertical line
+//     ctx.fillStyle = "#892be2";
+//     ctx.fillRect(xScaled, baseY, kLineWidth, amplitudeLineHeight);
+//     // I-beam
+//     const kIBeamWidth = 12;
+//     ctx.fillRect(xScaled - 0.5 * kIBeamWidth + 0.5 * kLineWidth, amplitudeY - kLineWidth, kIBeamWidth, kLineWidth);
+//     ctx.fillRect(xScaled - 0.5 * kIBeamWidth + 0.5 * kLineWidth, baseY - 0.5 * kLineWidth, kIBeamWidth, kLineWidth);
+//     // Draw (semi-opaque) background for the text
+//     const kTextTopPadding = 6;
+//     const kTextFontSize = 14;
+//     const kBoxWidth = 75;
+//     const kBoxHeight = kTextFontSize * 1.33;
+//     const textY = Math.max(18, amplitudeY - kTextTopPadding);
+//     ctx.fillStyle = "#ffffffb0";
+//     ctx.fillRect(xScaled + kIBeamWidth * 0.6, textY - kTextFontSize, kBoxWidth, kBoxHeight);
+//     // Label
+//     ctx.fillStyle = "#892be2";
+//     ctx.textAlign = "left";
+//     ctx.font = `${kTextFontSize}px Comfortaa, cursive`;
+//     ctx.fillText("Amplitude", xScaled + kIBeamWidth * 0.6, textY);
+//   }
+// };
 
-const drawWaveLengthMarker = (props: IDrawHelperProps) => {
-  const { ctx, width, height, zoom, data, pureToneFrequency } = props;
+        // -- commented out, but deliberately not removed, per: PT #180792001
+// const drawWaveLengthMarker = (props: IDrawHelperProps) => {
+//   const { ctx, width, height, zoom, data, pureToneFrequency } = props;
 
-  const kSampleDiff = 1;
-  const baseY = height * 0.5;
-  const pointsCount = getPointsCount(props);
-  // X samples point away from the center
-  const markerPadding = Math.min(pointsCount * 0.25, Math.round(20000 / zoom));
+//   const kSampleDiff = 1;
+//   const baseY = height * 0.5;
+//   const pointsCount = getPointsCount(props);
+//   // X samples point away from the center
+//   const markerPadding = Math.min(pointsCount * 0.25, Math.round(20000 / zoom));
 
-  const currentDataPointIdx = getCurrentSampleIdx(props);
+//   const currentDataPointIdx = getCurrentSampleIdx(props);
 
-  const startIdx = currentDataPointIdx + markerPadding;
+//   const startIdx = currentDataPointIdx + markerPadding;
 
-  let waveX1 = null; // X coord of the first sign change
-  let waveX2 = null; // X coord of the second sign change
-  let waveX3 = null; // X coord of the third sign change
-  for (let i = startIdx; i < currentDataPointIdx + pointsCount * 0.5; i++) {
-    const y1 = data[i - kSampleDiff];
-    const y2 = data[i + kSampleDiff];
-    if (y1 !== undefined && y2 !== undefined && Math.sign(y1) !== Math.sign(y2)) {
-      if (waveX1 === null) {
-        waveX1 = i;
-        i += kSampleDiff * 2;
-      } else if (waveX2 === null) {
-        waveX2 = i;
-        i += kSampleDiff * 2;
-      } else {
-        waveX3 = i;
-        break;
-      }
-    }
-  }
+//   let waveX1 = null; // X coord of the first sign change
+//   let waveX2 = null; // X coord of the second sign change
+//   let waveX3 = null; // X coord of the third sign change
+//   for (let i = startIdx; i < currentDataPointIdx + pointsCount * 0.5; i++) {
+//     const y1 = data[i - kSampleDiff];
+//     const y2 = data[i + kSampleDiff];
+//     if (y1 !== undefined && y2 !== undefined && Math.sign(y1) !== Math.sign(y2)) {
+//       if (waveX1 === null) {
+//         waveX1 = i;
+//         i += kSampleDiff * 2;
+//       } else if (waveX2 === null) {
+//         waveX2 = i;
+//         i += kSampleDiff * 2;
+//       } else {
+//         waveX3 = i;
+//         break;
+//       }
+//     }
+//   }
 
-  if (waveX1 !== null && waveX3 !== null) {
-    const kLineWidth = 3;
-    const xScale = width / pointsCount;
-    const minPointIdx = currentDataPointIdx - 0.5 * pointsCount; // currentDataPointIdx is always in the middle
-    const x1Scaled = (waveX1 - minPointIdx) * xScale;
-    const x3Scaled = (waveX3 - minPointIdx) * xScale;
+//   if (waveX1 !== null && waveX3 !== null) {
+//     const kLineWidth = 3;
+//     const xScale = width / pointsCount;
+//     const minPointIdx = currentDataPointIdx - 0.5 * pointsCount; // currentDataPointIdx is always in the middle
+//     const x1Scaled = (waveX1 - minPointIdx) * xScale;
+//     const x3Scaled = (waveX3 - minPointIdx) * xScale;
 
-    // Horizontal line
-    ctx.fillStyle = "#892be2";
-    ctx.fillRect(x1Scaled, baseY - 0.5 * kLineWidth, (x3Scaled - x1Scaled), kLineWidth);
+//     // Horizontal line
+//     ctx.fillStyle = "#892be2";
+//     ctx.fillRect(x1Scaled, baseY - 0.5 * kLineWidth, (x3Scaled - x1Scaled), kLineWidth);
 
-    // I-beam
-    const kIBeamWidth = 12;
-    ctx.fillRect(x1Scaled - kLineWidth, baseY - kIBeamWidth * 0.5, kLineWidth, kIBeamWidth);
-    ctx.fillRect(x3Scaled, baseY - kIBeamWidth * 0.5, kLineWidth, kIBeamWidth);
+//     // I-beam
+//     const kIBeamWidth = 12;
+//     ctx.fillRect(x1Scaled - kLineWidth, baseY - kIBeamWidth * 0.5, kLineWidth, kIBeamWidth);
+//     ctx.fillRect(x3Scaled, baseY - kIBeamWidth * 0.5, kLineWidth, kIBeamWidth);
 
-    // Draw (semi-opaque) background for the text
-    const kTextFontSize = 14;
-    const kTextTopPadding = 40;
-    const kBoxWidth = 150;
-    const kBoxHeight = kTextFontSize * 1.33;
-    ctx.fillStyle = "#ffffffb0";
-    ctx.fillRect((x1Scaled + x3Scaled) * 0.5 - 0.5 * kBoxWidth, baseY + 0.65 * kTextTopPadding, kBoxWidth, kBoxHeight);
+//     // Draw (semi-opaque) background for the text
+//     const kTextFontSize = 14;
+//     const kTextTopPadding = 40;
+//     const kBoxWidth = 150;
+//     const kBoxHeight = kTextFontSize * 1.33;
+//     ctx.fillStyle = "#ffffffb0";
+//     ctx.fillRect((x1Scaled + x3Scaled) * 0.5 - 0.5 * kBoxWidth, baseY + 0.65 * kTextTopPadding, kBoxWidth, kBoxHeight);
 
-    // Label
-    ctx.fillStyle = "#892be2";
-    ctx.textAlign = "center";
-    ctx.font = `${kTextFontSize} Comfortaa, cursive`;
-    const wavelengthInMs = 1 / (pureToneFrequency || 1) * 1000;
-    ctx.fillText(`Wave length: ${wavelengthInMs.toFixed(2)}ms`, (x1Scaled + x3Scaled) * 0.5, baseY + kTextTopPadding);
-  }
-};
+//     // Label
+//     ctx.fillStyle = "#892be2";
+//     ctx.textAlign = "center";
+//     ctx.font = `${kTextFontSize} Comfortaa, cursive`;
+//     const wavelengthInMs = 1 / (pureToneFrequency || 1) * 1000;
+//     ctx.fillText(`Wave length: ${wavelengthInMs.toFixed(2)}ms`, (x1Scaled + x3Scaled) * 0.5, baseY + kTextTopPadding);
+//   }
+// };
 
 export const useSoundWaveRendering = (canvasRef: RefObject<HTMLCanvasElement>, data: Float32Array, props: ISoundWaveProps) => {
   const { width, height, audioBuffer, volume, playbackProgress, zoom, zoomedInView, shouldDrawProgressMarker, shouldDrawWaveCaptions: shouldDrawAmplitudeWavelengthCaptions, pureToneFrequency } = props;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,3 @@
-export const ZOOM_BUTTONS_WIDTH = 130; // px, it should match width of zoom-buttons-container defined in CSS file
 const SIDE_MARGIN = 8; // Units: px. If changing; also change $margin, in vars.scss
 const BORDER_WIDTH = 2; // Units: px; If changing; also change: $borderWidth, in vars.scss
 export const SIDE_MARGIN_PLUS_BORDER = SIDE_MARGIN + BORDER_WIDTH; // Units: px;

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,8 @@ export interface ISoundWavePropsWithDataAndCarrier extends ISoundWavePropsWithDa
 }
 
 export type SoundName =
-  "middle-c"
+  "pick-sound"
+  | "middle-c"
   | "c2"
   | "baby-cry"
   | "rock-and-knock-drum-loop"

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,6 @@ export interface ISoundWaveProps {
   interactive?: boolean;
   onProgressUpdate?: (newProgress: number) => void;
   shouldDrawProgressMarker?: boolean;
-  shouldDrawWaveCaptions?: boolean;
   pureToneFrequency?: number;
   handleZoomOut?: () => void;
   handleZoomIn?: () => void;


### PR DESCRIPTION
Greatly refactors the UX (and a good amount of code) for the user sound recording feature. Also hides the components/code which implemented the feature to display the selected sound's amplitude and wavelength. Finally, also prompts user to pick a sound (no sound is selected by default). 

PT story: https://www.pivotaltracker.com/story/show/180792001

Story details:
- move Record command into a button with the microphone logo.
- Pressing Record brings up a dialog that says "Press OK to begin recording for 5 seconds."
- Press OK, record for 5 seconds, and switch the sound dropdown to "My Recording"
- Record button is disabled during playback.
- remove labeling button/feature entirely.

Demo video: 
https://user-images.githubusercontent.com/91078832/149231297-5fc5ce34-28dc-491d-958c-8646a0ef95cb.mov


