### PR TITLE
180971192 defaults

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -96,7 +96,7 @@ export const App = () => {
   const [selectedSound, setSelectedSound] = useState<SoundName>("pick-sound");
   const [playing, setPlaying] = useState<boolean>(false);
   const [volume, setVolume] = useState<number>(1);
-  const [zoom, setZoom] = useState<number>(16);
+  const [zoom, setZoom] = useState<number>(4);
   const [playbackProgress, setPlaybackProgress] = useState<number>(0);
   const [playbackRate, setPlaybackRate] = useState<number>(1);
   const [graphWidth, setGraphWidth] = useState<number>(100);

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -276,7 +276,7 @@ export const App = () => {
                 <Slider
                   className="volume-slider"
                   // Keep min volume > 0 so it's always possible to calculate amplitude and wave length markers
-                  min={0.01} max={2} step={0.01}
+                  min={0.01} max={2.5} step={0.01}
                   value={volume}
                   onChange={handleVolumeChange}
                 />

--- a/src/components/carrier-wave/carrier-wave.tsx
+++ b/src/components/carrier-wave/carrier-wave.tsx
@@ -24,8 +24,8 @@ export const CarrierWave = (props: ICarrierWaveProps) => {
 
   const [carrierBuffer, setCarrierBuffer] = useState<AudioBuffer>();
   const [carrierZoom, setCarrierZoom] = useState<number>(16);
-  const [carrierFrequency, setCarrierFrequency] = useState<number>(0);
-  const [modulation, setModulation] = useState<string>("");
+  const [carrierFrequency, setCarrierFrequency] = useState<number>(2e3);
+  const [modulation, setModulation] = useState<string>("AM");
 
   useEffect(() => {
     if (audioBuffer && carrierFrequency !== 0 && modulation !== "") {


### PR DESCRIPTION
PT story: https://www.pivotaltracker.com/story/show/180971192

Story features (note: fourth feature moved to separate ticket), set the apps defaults such that:

- Set Modulation to AM
- Set carrier frequency to 2 kHz
- Set full volume such that straight sine waves touch the top and bottom of the graph window, but open at half volume

Screen shot showing 'on load' defaults, except with a sound selected, and volume set to full:
<img width="445" alt="Screen Shot 2022-01-26 at 5 03 11 PM" src="https://user-images.githubusercontent.com/91078832/151254565-dd93a5d5-9dd0-4b5f-8ef8-9c79a2d71a25.png">

