### PR TITLE
Changed layout of "Record" button and its children

### DIFF
--- a/src/components/sound-picker/sound-picker.scss
+++ b/src/components/sound-picker/sound-picker.scss
@@ -25,14 +25,11 @@
   }
 
   .icons-container {
-    button {
-      width: 95px;
-      height: 30px;
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      flex-direction: row;
+    height: 30px;
 
+    button {
+      min-width: 100px !important;
+      padding: 0;
       border-radius: 10px;
       line-height: 1;
       background-color: $controlsBackgroundColor;
@@ -41,16 +38,13 @@
       &[disabled] {
         color: $disabledButtonColor;
       }
-
-      div {
-        font-size: 110%;
-      }
     }
 
     .icon {
+      position: relative;
+      top: 2px;
       height: 24px;
       width: 24px;
-      margin-top: 4px;
       cursor: pointer;
       fill: red;
 
@@ -68,6 +62,11 @@
         fill: $disabledButtonColor;
         cursor: default;
       }
+    }
+
+    .caption {
+      position: relative;
+      top: -5px;
     }
   }
 }

--- a/src/components/sound-picker/sound-picker.tsx
+++ b/src/components/sound-picker/sound-picker.tsx
@@ -187,12 +187,13 @@ export const SoundPicker = (props: ISoundPickerProps) => {
 
       <div className="icons-container">
         <button disabled={playing} onClick={onMicIconClicked}>
-          <div>
+          <span>
             <MicIcon className={
               `icon button ${playing ? "disabled" : ""} ${isRecording ? "recording" : ""}`}
               />
-          </div>
-          <div>Record</div>
+          </span>
+          <span className="caption">Record&nbsp;&nbsp;</span>
+
         </button>
       </div>
 

--- a/src/components/sound-picker/sound-picker.tsx
+++ b/src/components/sound-picker/sound-picker.tsx
@@ -193,7 +193,6 @@ export const SoundPicker = (props: ISoundPickerProps) => {
               />
           </span>
           <span className="caption">Record&nbsp;&nbsp;</span>
-
         </button>
       </div>
 


### PR DESCRIPTION
PT Ticket: https://www.pivotaltracker.com/story/show/181036761

Bug Synopsis: "The Record button text shoves over the side of the button."

Screen shot of how issue appeared to the original reporter (note the text string clipping on the "Record" button; UL corner):
![RecordBadDisplay](https://user-images.githubusercontent.com/91078832/151261830-c833e0b4-2898-46c4-9368-cc9f85a1dd62.png)