### PR TITLE
Quashed false positive linter warning with a linter control comment

### DIFF
--- a/src/components/carrier-wave/carrier-wave.tsx
+++ b/src/components/carrier-wave/carrier-wave.tsx
@@ -18,6 +18,7 @@ export interface ICarrierWaveProps {
   interactive: boolean;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- false positive warning; CarrierWave is imported, and used in app.tsx
 export const CarrierWave = (props: ICarrierWaveProps) => {
   const { audioBuffer, playbackProgress, graphWidth, graphHeight, volume,
     onProgressUpdate, interactive } = props;

--- a/src/components/carrier-wave/carrier-wave.tsx
+++ b/src/components/carrier-wave/carrier-wave.tsx
@@ -1,12 +1,11 @@
 import React, { useEffect, useState } from "react";
-import { Modulation, ZOOMED_OUT_GRAPH_HEIGHT } from "../../types";
+import { ZOOMED_OUT_GRAPH_HEIGHT } from "../../types";
 import { getAMCarrierWave, getFMCarrierWave } from "../../utils/audio";
 import { ButtonGroup } from "../button-group/button-group";
 import { SoundWave } from "../sound-wave";
 
 import "./carrier-wave.scss";
 
-type CarrierWave = { modulation: Modulation, frequency: number };
 
 export interface ICarrierWaveProps {
   audioBuffer?: AudioBuffer; // This is the buffer for the user-chosen sound; and NOT the carrier wave
@@ -18,7 +17,7 @@ export interface ICarrierWaveProps {
   interactive: boolean;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- false positive warning; CarrierWave is imported, and used in app.tsx
+
 export const CarrierWave = (props: ICarrierWaveProps) => {
   const { audioBuffer, playbackProgress, graphWidth, graphHeight, volume,
     onProgressUpdate, interactive } = props;


### PR DESCRIPTION
Previously, the linter was giving a (false positive) warning:
```
jabbott:soundwaves jabbott$ npm run lint

> soundwaves@0.0.1 lint
> eslint "./src/**/*.{js,jsx,ts,tsx}" "./cypress/**/*.{js,jsx,ts,tsx}"

/Users/jabbott/repos/soundwaves/src/components/carrier-wave/carrier-wave.tsx
  21:14  warning  'CarrierWave' is assigned a value but never used  @typescript-eslint/no-unused-vars

✖ 1 problem (0 errors, 1 warning)
```
HOWEVER, the `CarrierWave` React component is actually imported into the main component, `app.tsx`, and is used there; so this is a false positive report. This false positive report was first observed in my local development environment, but recently I also observed it in our CI environment, when I made a commit on an un-related branch.

Also of note: the project's configured eslint version, `"^7.32.0"` is the running version (as reported by: `npx eslint --version`), and is the 'highest' (most recent) 7.N.N version available on the eslint repo on GitHub. The project's `.eslintrc.js` file also appears to be using the TypeScript-specific version of this rule:

```
. . .
  rules: {
. . .
    "@typescript-eslint/no-unused-vars": ["warn", { args: "none", ignoreRestSiblings: true }],
. . .
    "no-unused-vars": "off",  // superceded by @typescript-eslint/no-unused-vars
```