### PR TITLE
Update downsampling algorithm not to use mult of 2 as its min sample rate

### DIFF
--- a/src/utils/audio.ts
+++ b/src/utils/audio.ts
@@ -8,7 +8,10 @@ export const getMinValue = (data: Float32Array) => {
   return min;
 };
 
-const MIN_SAMPLE_RATE = 8000; // limit defined by Web Audio API
+// WebAudio API's (maximum required) minimum rate is 8kHz.
+// However 8kHz interferes with AM / FM modulation that uses 2 / 4 / 8kHz as carrier wave.
+// This might result in flat sound wave. So, use frequency that isn't multitude of 2.
+const MIN_SAMPLE_RATE = 9000;
 
 export const downsampleAudioBuffer = async (audioBuffer: AudioBuffer, newSamplesCount: number): Promise<Float32Array> => {
   const ratio = newSamplesCount / audioBuffer.length;


### PR DESCRIPTION
[#180971227]

When AM modulation with the 8kHz carrier wave was used, users could still see a flat sound wave. See: https://www.pivotaltracker.com/story/show/180971227/comments/229405983

Previous attempt to fix these issues: https://github.com/concord-consortium/soundwaves/pull/32

This was caused by the downsampling algorithm that sometimes was using 8kHz sample rate. Apparently, 8kHz sample rate doesn't work with a perfect 8kHz sine wave used by AM modulation. 😉 This might also mean that the naive downsampling could work fine - I guess it was only making this issue worse and visible even for lower carrier wave frequencies. But if no one complains about performance, maybe it's better not to use it.