### PR TITLE
Fix time labels

### DIFF
--- a/src/hooks/use-sound-wave-rendering.ts
+++ b/src/hooks/use-sound-wave-rendering.ts
@@ -13,12 +13,12 @@ const drawBackground = (props: IDrawHelperProps) => {
 };
 
 const drawTimeCaptions = (props: IDrawHelperProps) => {
-  const { ctx, width, height, audioBuffer } = props;
+  const { ctx, width, height, audioBuffer, data } = props;
 
   // Need the audioBuffer to calculate
   if (!audioBuffer) { return; }
 
-  const timePerSample = 1 / audioBuffer.sampleRate;
+  const timePerSample = audioBuffer.duration / data.length;
   const currentDataPointIdx = getCurrentSampleIdx(props);
   const zoomedInViewPointsCount = getZoomedInViewPointsCount(props);
   const leftRightOffsetInSamples = (zoomedInViewPointsCount / 2);


### PR DESCRIPTION
[#181260008]

Previous calculations assumed that rendered data length is equal to `audioBuffer` samples count. This is not true because of downsampling.

To see the issue and the fix:
Open: https://soundwaves.concord.org/
Pick "baby cry". Note that the reported sound file length is around 4s. However, the real value is 18s.

If you open this branch, it should show ~18s.