### PR TITLE
Fix initial state and rm closed AudioContext to avoid issues

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -51,6 +51,7 @@ const setupAudioContext = async (
   if (audioSource.current && audioContext.current) {
     audioSource.current.stop();
     await audioContext.current.close();
+    audioContext.current = undefined;
     setPlaying(false);
   }
 
@@ -75,8 +76,7 @@ const setupAudioContext = async (
     // Note: previously we had code here that attempted to create a new
     // AudioContext; that resulted in a run-time error in desktop Chrome on
     // macOS (see: https://www.pivotaltracker.com/story/show/180792030).
-    const emptyAudioBuffer = new AudioBuffer({length: 1, sampleRate: 8000});
-    setAudioBuffer(emptyAudioBuffer);
+    setAudioBuffer(undefined);
     setPlaybackProgress(0);
     return;
   }

--- a/src/components/carrier-wave/carrier-wave.tsx
+++ b/src/components/carrier-wave/carrier-wave.tsx
@@ -37,6 +37,8 @@ export const CarrierWave = (props: ICarrierWaveProps) => {
         setCarrierBuffer(buffer);
       };
       updateCarrierBuffer();
+    } else {
+      setCarrierBuffer(undefined);
     }
   }, [audioBuffer, carrierFrequency, volume, modulation]);
 

--- a/src/components/sound-wave.tsx
+++ b/src/components/sound-wave.tsx
@@ -24,6 +24,7 @@ export const SoundWave = (props: ISoundWaveProps) => {
 
   useEffect(() => {
     if (!audioBuffer) {
+      setData(new Float32Array(0));
       return;
     }
     const actualZoom = zoomedInView ? zoom : 1;


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181274623

Hopefully the last PR for a while. I've found two more issues.

1. Open: https://soundwaves.concord.org/
Do not pick any sound.
Note that carrier wave has a line and progress handle that doesn't do anything.

2. Open: https://soundwaves.concord.org/
Pick "Middle C". Play it. Select "Pick Sound". Select "Middle C" again. JS error is triggered and the app doesn't work anymore.

This PR should fix both of them.